### PR TITLE
Give a fresh install an sslip.io domain and HTTPS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,7 +579,8 @@ credential lying around for nothing; keys are self-service.
 
 ## Instance settings
 
-The domain and the Let's Encrypt contact address are rows in `settings`,
+The domain and the Let's Encrypt contact address (optional: an account
+opens without one, so TLS follows the domain alone) are rows in `settings`,
 not environment variables: Cubeship is installed with one command,
 reached by IP, and configured from there. `config.Load` therefore
 requires nothing, and `config.SeedSettings` carries the old environment

--- a/README.md
+++ b/README.md
@@ -94,16 +94,24 @@ the API there too — bypassing Traefik's TLS. A fresh box has no domain
 and no certificate, so this is the only way in and it has to be
 reachable; a password and a session cookie cross it in the clear.
 
-Once a domain is set, everything is reachable over HTTPS at
-`api.<domain>` and 3000 has no remaining use from outside. Close it then,
-and open only 80 and 443.
+Once a domain is set, everything is reachable over HTTPS at `<domain>`
+and 3000 has no remaining use from outside. Close it then, and open only
+80 and 443.
+
+The installer sets one for you: it looks up the box's public address and
+uses `<a-b-c-d>.sslip.io`, a wildcard DNS name that resolves to
+`a.b.c.d` with nothing to register, so a fresh install answers over
+HTTPS at a name a certificate can be issued for. `--domain` (or
+`CUBESHIP_DOMAIN`) uses yours instead, and `CUBESHIP_ACME_EMAIL` gives
+Let's Encrypt a contact address — optional, an account opens without
+one.
 
 ## Claiming the instance
 
-Open `http://<ip>:3000` and create the account. A fresh instance has no
-account and no way to add one from outside, so this first page creates a
-super-admin, an organization and a project, signs you in, and closes
-setup for good — every account after it is added from inside.
+Open the address the installer printed and create the account. A fresh
+instance has no account and no way to add one from outside, so this
+first page creates an admin, signs you in, and closes setup for good —
+every account after it is added from inside.
 
 **Until you do this, whoever reaches that port first owns the instance.**
 Claim it as soon as the daemon starts; it says so in its log while the
@@ -114,17 +122,18 @@ You are signed in with a session cookie. For `cubeship login` and
 
 ## Configuring the instance
 
-Until a domain is set there is no registry to push to, and until a
-contact address is set there are no certificates, so apps are served over
-plain HTTP. Both are under **Instance** in the dashboard, or:
+Until a domain is set there is no registry to push to and no
+certificates, so apps are served over plain HTTP. The installer's
+sslip.io name covers both; to move to your own, under **Instance** in
+the dashboard, or:
 
 ```sh
-curl -X PUT https://api.example.com/api/settings \
+curl -X PUT https://example.com/api/settings \
   -H "Authorization: Bearer $KEY" \
   -d '{"domain":"example.com","acme_email":"admin@example.com"}'
 ```
 
-Both `api.<domain>` and `registry.<domain>` must resolve to this host for
+Both `<domain>` and `registry.<domain>` must resolve to this host for
 certificates to issue. Applying this replaces the affected containers,
 which costs a few seconds of downtime for them; apps already running keep
 the routing they were deployed with, so **redeploy them to serve over

--- a/cmd/cubeshipd/main.go
+++ b/cmd/cubeshipd/main.go
@@ -211,7 +211,7 @@ func applyInfrastructure(ctx context.Context, cfg *config.Config, docker *docker
 	}
 
 	if err := bootstrap.Ensure(ctx, docker,
-		bootstrap.TraefikContainerOpts(cfg, values.Get(settings.ACMEEmail))); err != nil {
+		bootstrap.TraefikContainerOpts(cfg, values.HasTLS(), values.Get(settings.ACMEEmail))); err != nil {
 		return fmt.Errorf("bootstrap traefik: %w", err)
 	}
 

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,14 @@ NETWORK=cubeship
 DATA_DIR="${CUBESHIP_DATA_DIR:-/var/lib/cubeship}"
 PORT=3000
 
+# DOMAIN is where the instance answers over HTTPS. Left empty, one is
+# made from the box's public address under sslip.io — a wildcard DNS
+# service that resolves <a-b-c-d>.sslip.io to a.b.c.d — so a fresh
+# install has a name and a certificate before anyone owns a domain.
+# ACME_EMAIL is the contact Let's Encrypt registers, and is optional.
+DOMAIN="${CUBESHIP_DOMAIN:-}"
+ACME_EMAIL="${CUBESHIP_ACME_EMAIL:-}"
+
 say() { printf '  %s\n' "$*"; }
 die() { printf '\nerror: %s\n' "$*" >&2; exit 1; }
 
@@ -53,17 +61,21 @@ require_linux() {
 
 usage() {
 	cat <<-USAGE
-		Usage: install.sh [--local]
+		Usage: install.sh [--local] [--domain <name>]
 
 		  --local   Build the image from the checkout this script is in,
 		            instead of pulling a published one. Requires the
 		            repository; the build itself runs inside Docker.
+		  --domain  Where the instance answers. Must resolve to this box.
+		            Without it, <public-ip>.sslip.io is used, which does.
 
 		Environment:
 		  CUBESHIP_IMAGE      daemon image to pull (default $IMAGE)
 		  CUBESHIP_WEB_IMAGE  dashboard image to pull (default $WEB_IMAGE)
 		  CUBESHIP_VERSION    tag to pull (default $VERSION)
 		  CUBESHIP_DATA_DIR   where the instance keeps its state (default $DATA_DIR)
+		  CUBESHIP_DOMAIN     same as --domain
+		  CUBESHIP_ACME_EMAIL contact address for Let's Encrypt (optional)
 	USAGE
 }
 
@@ -71,6 +83,8 @@ parse_args() {
 	while [ $# -gt 0 ]; do
 		case "$1" in
 			--local) LOCAL=1 ;;
+			--domain) shift; [ $# -gt 0 ] || die "--domain needs a name"; DOMAIN="$1" ;;
+			--domain=*) DOMAIN="${1#--domain=}" ;;
 			-h | --help) usage; exit 0 ;;
 			*) usage >&2; die "unknown option: $1" ;;
 		esac
@@ -181,6 +195,8 @@ run_daemon() {
 		-v "$DATA_DIR:$DATA_DIR" \
 		-e CUBESHIP_DATA_DIR="$DATA_DIR" \
 		-e CUBESHIP_WEB_IMAGE="$WEB_IMAGE:$VERSION" \
+		-e CUBESHIP_DOMAIN="$DOMAIN" \
+		-e CUBESHIP_ACME_EMAIL="$ACME_EMAIL" \
 		-p "$PORT:$PORT" \
 		"$IMAGE:$VERSION" >/dev/null ||
 		die "could not start $CONTAINER. See: docker logs $CONTAINER"
@@ -198,12 +214,36 @@ wait_for_health() {
 	die "the daemon did not come up. See: docker logs $CONTAINER"
 }
 
-# address is where to tell the operator to point their browser. It is the
-# host's own routable address, not a public one looked up over the
-# network — an installer should not phone anywhere.
+# address is the host's own routable address, the fallback for telling
+# the operator where to open when no domain could be made.
 address() {
 	ip route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<NF;i++) if ($i=="src") {print $(i+1); exit}}' ||
 		hostname -I 2>/dev/null | awk '{print $1}'
+}
+
+# public_ip asks the outside world, because that is the only place the
+# answer is: behind a cloud NAT the routable address is private. Three
+# services, the first that answers with an IPv4 wins; none answering is
+# not an error, it is an install with no domain.
+public_ip() {
+	for url in https://api.ipify.org https://ifconfig.me/ip https://icanhazip.com; do
+		ip=$(curl -fsS --max-time 5 "$url" 2>/dev/null | tr -d '[:space:]')
+		case "$ip" in
+			*[!0-9.]* | "") continue ;;
+		esac
+		echo "$ip"
+		return 0
+	done
+	return 1
+}
+
+# default_domain fills DOMAIN when nothing was given, or says why it
+# could not.
+default_domain() {
+	[ -z "$DOMAIN" ] || return 0
+	ip=$(public_ip) || return 0
+	DOMAIN="$(printf '%s' "$ip" | tr . -).sslip.io"
+	say "No domain given; using $DOMAIN"
 }
 
 main() {
@@ -218,6 +258,7 @@ main() {
 	docker inspect "$CONTAINER" >/dev/null 2>&1 || check_port
 
 	ensure_docker
+	default_domain
 	run_daemon
 
 	say "Waiting for the daemon…"
@@ -226,16 +267,35 @@ main() {
 	host=$(address)
 	[ -n "$host" ] || host="<this host's address>"
 
+	if [ -n "$DOMAIN" ]; then
+		cat <<-DONE
+
+			Cubeship is running.
+
+			  Open  https://$DOMAIN
+
+			Ports 80 and 443 must be open; the certificate is issued on the
+			first visit, which can take a minute. Until then, or if $DOMAIN
+			does not reach this box, http://$host:$PORT is the way in.
+
+		DONE
+	else
+		cat <<-DONE
+
+			Cubeship is running.
+
+			  Open  http://$host:$PORT
+
+			No public address could be found, so there is no domain yet. Set
+			one from the dashboard, and close port $PORT at the firewall once
+			HTTPS is up.
+
+		DONE
+	fi
+
 	cat <<-DONE
-
-		Cubeship is running.
-
-		  Open  http://$host:$PORT
-
 		The first person to open it creates the account — until someone
-		does, anyone who can reach that port can claim this instance. Set
-		your domain from the dashboard afterwards, and close port $PORT at
-		the firewall once HTTPS is up.
+		does, anyone who can reach this instance can claim it.
 
 		  docker ps
 		  docker logs -f $CONTAINER

--- a/install.sh
+++ b/install.sh
@@ -202,16 +202,56 @@ run_daemon() {
 		die "could not start $CONTAINER. See: docker logs $CONTAINER"
 }
 
+# The daemon only listens once its siblings are up, and on a first
+# install that is four images to pull — minutes on a slow box, with
+# nothing to show for it. So its log is streamed here while we wait:
+# the `bootstrap:` lines say which image is being pulled and which
+# container just started, and that is exactly what the wait is.
 wait_for_health() {
+	progress=$(mktemp)
+	docker logs -f "$CONTAINER" >"$progress" 2>&1 &
+	logs=$!
+	shown=0
+
 	i=0
-	while [ "$i" -lt 60 ]; do
+	while [ "$i" -lt 300 ]; do
+		report_progress
 		if curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+			report_progress
+			kill "$logs" 2>/dev/null
+			rm -f "$progress"
 			return 0
 		fi
 		i=$((i + 1))
 		sleep 2
 	done
+	kill "$logs" 2>/dev/null
+	rm -f "$progress"
 	die "the daemon did not come up. See: docker logs $CONTAINER"
+}
+
+# report_progress prints the daemon's `bootstrap:` lines that arrived
+# since the last call. The log is a file rather than a pipe so that the
+# one process to stop afterwards is `docker logs` itself — a pipeline in
+# the background would outlive the script and keep writing to the
+# terminal after it.
+report_progress() {
+	total=$(wc -l <"$progress" | tr -d ' ')
+	[ "$total" -gt "$shown" ] || return 0
+	sed -n "$((shown + 1)),${total}p" "$progress" | sed -n 's/.*bootstrap: /    /p'
+	shown=$total
+}
+
+banner() {
+	cat <<-'ART'
+
+		   ██████╗██╗   ██╗██████╗ ███████╗███████╗██╗  ██╗██╗██████╗
+		  ██╔════╝██║   ██║██╔══██╗██╔════╝██╔════╝██║  ██║██║██╔══██╗
+		  ██║     ██║   ██║██████╔╝█████╗  ███████╗███████║██║██████╔╝
+		  ██║     ██║   ██║██╔══██╗██╔══╝  ╚════██║██╔══██║██║██╔═══╝
+		  ╚██████╗╚██████╔╝██████╔╝███████╗███████║██║  ██║██║██║
+		   ╚═════╝ ╚═════╝ ╚═════╝ ╚══════╝╚══════╝╚═╝  ╚═╝╚═╝╚═╝
+	ART
 }
 
 # address is the host's own routable address, the fallback for telling
@@ -267,6 +307,7 @@ main() {
 	host=$(address)
 	[ -n "$host" ] || host="<this host's address>"
 
+	banner
 	if [ -n "$DOMAIN" ]; then
 		cat <<-DONE
 

--- a/internal/app/mcp.go
+++ b/internal/app/mcp.go
@@ -50,7 +50,7 @@ func (t *Tools) Register(srv *mcp.Server) {
 	}, t.get)
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "deploy_app",
-		Description: `Manually redeploy an app from an image tag already pushed to its registry path (tag defaults to "latest"). Waits for the deploy to finish and reports the outcome; if this call times out first, the deploy carries on regardless — check it with get_app_deployments. Requires member role in the organization.`,
+		Description: `Manually redeploy an app from an image tag already pushed to its registry path (no tag means "latest" for an image, or the stored ref for a source that builds). Waits for the deploy to finish and reports the outcome; if this call times out first, the deploy carries on regardless — check it with get_app_deployments. Requires member role in the organization.`,
 	}, t.deploy)
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "get_app_env",
@@ -166,9 +166,6 @@ type deployInput struct {
 
 func (t *Tools) deploy(ctx context.Context, _ *mcp.CallToolRequest, in deployInput) (*mcp.CallToolResult, user.ActionResult, error) {
 	tag := in.Tag
-	if tag == "" {
-		tag = "latest"
-	}
 	ref, err := ParseReference(in.App)
 	if err != nil {
 		return nil, user.ActionResult{}, err
@@ -221,6 +218,7 @@ func (t *Tools) deployments(ctx context.Context, _ *mcp.CallToolRequest, in name
 }
 
 func (t *Tools) delete(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, user.ActionResult, error) {
+	tag := in.Tag
 	ref, err := ParseReference(in.App)
 	if err != nil {
 		return nil, user.ActionResult{}, err
@@ -237,6 +235,7 @@ type envOutput struct {
 }
 
 func (t *Tools) getEnv(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, envOutput, error) {
+	tag := in.Tag
 	ref, err := ParseReference(in.App)
 	if err != nil {
 		return nil, envOutput{}, err
@@ -261,6 +260,7 @@ func (t *Tools) setEnv(ctx context.Context, _ *mcp.CallToolRequest, in setEnvInp
 	if len(in.Set) == 0 && len(in.Unset) == 0 {
 		return nil, user.ActionResult{}, fmt.Errorf("give set, unset, or both")
 	}
+	tag := in.Tag
 	ref, err := ParseReference(in.App)
 	if err != nil {
 		return nil, user.ActionResult{}, err
@@ -282,6 +282,7 @@ func (t *Tools) logs(ctx context.Context, _ *mcp.CallToolRequest, in logsInput) 
 	if tail == "" {
 		tail = mcpDefaultLogTail
 	}
+	tag := in.Tag
 	ref, err := ParseReference(in.App)
 	if err != nil {
 		return nil, nil, err

--- a/internal/app/mcp.go
+++ b/internal/app/mcp.go
@@ -218,7 +218,6 @@ func (t *Tools) deployments(ctx context.Context, _ *mcp.CallToolRequest, in name
 }
 
 func (t *Tools) delete(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, user.ActionResult, error) {
-	tag := in.Tag
 	ref, err := ParseReference(in.App)
 	if err != nil {
 		return nil, user.ActionResult{}, err
@@ -235,7 +234,6 @@ type envOutput struct {
 }
 
 func (t *Tools) getEnv(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, envOutput, error) {
-	tag := in.Tag
 	ref, err := ParseReference(in.App)
 	if err != nil {
 		return nil, envOutput{}, err
@@ -260,7 +258,6 @@ func (t *Tools) setEnv(ctx context.Context, _ *mcp.CallToolRequest, in setEnvInp
 	if len(in.Set) == 0 && len(in.Unset) == 0 {
 		return nil, user.ActionResult{}, fmt.Errorf("give set, unset, or both")
 	}
-	tag := in.Tag
 	ref, err := ParseReference(in.App)
 	if err != nil {
 		return nil, user.ActionResult{}, err
@@ -282,7 +279,6 @@ func (t *Tools) logs(ctx context.Context, _ *mcp.CallToolRequest, in logsInput) 
 	if tail == "" {
 		tail = mcpDefaultLogTail
 	}
-	tag := in.Tag
 	ref, err := ParseReference(in.App)
 	if err != nil {
 		return nil, nil, err

--- a/internal/app/openapi.go
+++ b/internal/app/openapi.go
@@ -160,9 +160,9 @@ func (h *Handler) OpenAPI() openapi.Spec {
 					Tags:        []string{"Apps"},
 					Parameters:  refParams,
 					RequestBody: &openapi.RequestBody{
-						Description: `Optional. Omit the body entirely to deploy "latest".`,
+						Description: `Optional. Omit the body to deploy "latest", or, for a source that builds, its stored ref.`,
 						Content: openapi.JSON(openapi.Object(map[string]*openapi.Schema{
-							"tag": openapi.String(`Image tag to deploy. Defaults to "latest".`),
+							"tag": openapi.String(`Image tag, or ref to build. Defaults to "latest" or the app's stored ref.`),
 						})),
 					},
 					Responses: openapi.Responses{

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -325,10 +325,11 @@ func (s *Service) MergeEnv(ctx context.Context, caller *user.User, ref Reference
 // registry path, and returns the deployment recording it. The work runs
 // detached — see Orchestrator.Start — so the caller can stop waiting
 // without stopping the deploy.
+//
+// An empty tag is the source's to fill in: "latest" for an image, the
+// stored ref for a source that builds. Defaulting it here turned every
+// build with no tag asked for into a build of a branch called latest.
 func (s *Service) Deploy(ctx context.Context, caller *user.User, ref Reference, tag string) (*Scoped, *Deployment, error) {
-	if tag == "" {
-		tag = "latest"
-	}
 	// Resolved as a member first, so someone outside the organization
 	// gets the same 404 an unknown app gets rather than learning it
 	// exists. The source's own requirement is checked after.

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -346,6 +346,12 @@ func (s *Service) Deploy(ctx context.Context, caller *user.User, ref Reference, 
 	return a, deployment, nil
 }
 
+// WaitForDeploys blocks until every deploy the orchestrator has running
+// has finished. For tests: a deploy started by a webhook outlives the
+// request that started it, and a test that drops its schema while one
+// is still writing deadlocks in Postgres.
+func (s *Service) WaitForDeploys() { s.orch.Wait() }
+
 // WaitForDeployment blocks until a deployment finishes or ctx is done.
 // Abandoning the wait does not abandon the deploy.
 func (s *Service) WaitForDeployment(ctx context.Context, caller *user.User, ref Reference, deploymentID int64) (*Deployment, error) {

--- a/internal/platform/bootstrap/bootstrap.go
+++ b/internal/platform/bootstrap/bootstrap.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"cubeship/internal/platform/config"
@@ -332,9 +333,18 @@ func BuildKitSocket(cfg *config.Config) string {
 // is not incorrect, only slow, but slow builds are the thing a cache
 // exists to prevent.
 func BuildKitContainerOpts(cfg *config.Config) dockerx.ContainerOpts {
+	// buildkitd creates its socket as root. The daemon in its container
+	// is root too; on the host (`make dev`, CI) it is whoever ran it, and
+	// a socket it cannot open is a builder that is never available.
+	// buildkitd's --group hands the socket to that user's group instead.
+	var cmd []string
+	if !cfg.InContainer {
+		cmd = []string{"--group", strconv.Itoa(os.Getgid())}
+	}
 	return dockerx.ContainerOpts{
 		Name:       BuildKitContainerName,
 		Image:      BuildKitImage,
+		Cmd:        cmd,
 		Privileged: true,
 		Binds: []string{
 			cfg.DataDir + "/buildkit:/var/lib/buildkit",

--- a/internal/platform/bootstrap/bootstrap.go
+++ b/internal/platform/bootstrap/bootstrap.go
@@ -426,15 +426,16 @@ func EnsureBuildKit(ctx context.Context, docker dockerAPI, cfg *config.Config) e
 	return Ensure(ctx, docker, BuildKitContainerOpts(cfg))
 }
 
-// TraefikContainerOpts describes the proxy. An empty acmeEmail means no
-// certificate resolver at all: Let's Encrypt will not register an account
-// without a contact address, so until one is configured apps are served
-// over plain HTTP.
+// TraefikContainerOpts describes the proxy. With tls false there is no
+// certificate resolver at all: nothing has a name to get a certificate
+// for, so apps are served over plain HTTP. acmeEmail is the contact
+// address Let's Encrypt registers, and may be empty — an account is
+// opened without one.
 //
-// Adding the email later changes these options, which is what makes
+// Setting a domain later changes these options, which is what makes
 // Ensure replace the container — the resolver cannot be added to a
 // running one.
-func TraefikContainerOpts(cfg *config.Config, acmeEmail string) dockerx.ContainerOpts {
+func TraefikContainerOpts(cfg *config.Config, tls bool, acmeEmail string) dockerx.ContainerOpts {
 	cmd := []string{
 		"--providers.docker=true",
 		"--providers.docker.exposedbydefault=false",
@@ -444,10 +445,9 @@ func TraefikContainerOpts(cfg *config.Config, acmeEmail string) dockerx.Containe
 		"--entrypoints.websecure.address=:443",
 		"--api.dashboard=false",
 	}
-	if acmeEmail != "" {
+	if tls {
 		cmd = append(cmd,
 			"--certificatesresolvers.letsencrypt.acme.tlschallenge=true",
-			"--certificatesresolvers.letsencrypt.acme.email="+acmeEmail,
 			"--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json",
 			// Redirecting :80 is only right once :443 can actually serve.
 			// Without a resolver it would send every visitor to a port
@@ -455,6 +455,9 @@ func TraefikContainerOpts(cfg *config.Config, acmeEmail string) dockerx.Containe
 			"--entrypoints.web.http.redirections.entryPoint.to=websecure",
 			"--entrypoints.web.http.redirections.entryPoint.scheme=https",
 			"--entrypoints.web.http.redirections.entryPoint.permanent=true")
+		if acmeEmail != "" {
+			cmd = append(cmd, "--certificatesresolvers.letsencrypt.acme.email="+acmeEmail)
+		}
 	}
 	return dockerx.ContainerOpts{
 		Name:  "cubeship-traefik",

--- a/internal/platform/bootstrap/bootstrap.go
+++ b/internal/platform/bootstrap/bootstrap.go
@@ -647,6 +647,10 @@ func Ensure(ctx context.Context, docker dockerAPI, opts dockerx.ContainerOpts) e
 		return err
 	}
 	if imageID == "" {
+		// Said before rather than after: on a first install these pulls
+		// are most of the wait, and the installer streams these lines
+		// so the person watching knows what the wait is.
+		log.Printf("bootstrap: pulling %s for %s", opts.Image, opts.Name)
 		if err := docker.PullImage(ctx, opts.Image, nil); err != nil {
 			return fmt.Errorf("pull %s: %w (if this image was built on this host, it is not there — check the tag)", opts.Image, err)
 		}
@@ -695,6 +699,7 @@ func Ensure(ctx context.Context, docker dockerAPI, opts dockerx.ContainerOpts) e
 	if err := docker.StartContainer(ctx, id); err != nil {
 		return fmt.Errorf("start %s: %w", opts.Name, err)
 	}
+	log.Printf("bootstrap: %s started", opts.Name)
 	return nil
 }
 

--- a/internal/platform/bootstrap/bootstrap_test.go
+++ b/internal/platform/bootstrap/bootstrap_test.go
@@ -145,7 +145,7 @@ func TestWriteRegistryTokenCertWritesFile(t *testing.T) {
 }
 
 func TestTraefikContainerOpts(t *testing.T) {
-	opts := TraefikContainerOpts(testConfig(), "admin@example.com")
+	opts := TraefikContainerOpts(testConfig(), true, "admin@example.com")
 
 	if len(opts.Binds) != 3 {
 		t.Fatalf("expected docker socket + acme storage + dynamic config binds, got %v", opts.Binds)
@@ -540,7 +540,7 @@ func TestConfigHashTracksTheOptions(t *testing.T) {
 // Plain HTTP used to answer 404 for everything, since nothing was routed
 // on :80.
 func TestTraefikRedirectsHTTPToHTTPS(t *testing.T) {
-	opts := TraefikContainerOpts(testConfig(), "admin@example.com")
+	opts := TraefikContainerOpts(testConfig(), true, "admin@example.com")
 
 	for _, want := range []string{
 		"--entrypoints.web.http.redirections.entryPoint.to=websecure",
@@ -558,15 +558,15 @@ func TestTraefikRedirectsHTTPToHTTPS(t *testing.T) {
 	}
 }
 
-// Until a contact address is configured, Traefik must have no ACME
-// resolver at all — Let's Encrypt will not register an account without
-// one — and must not redirect :80 to a port that cannot serve.
-func TestTraefikWithoutAnACMEEmailHasNoResolver(t *testing.T) {
-	opts := TraefikContainerOpts(testConfig(), "")
+// Until a domain is configured, Traefik must have no ACME resolver at
+// all — there is nothing to get a certificate for — and must not
+// redirect :80 to a port that cannot serve.
+func TestTraefikWithoutADomainHasNoResolver(t *testing.T) {
+	opts := TraefikContainerOpts(testConfig(), false, "")
 
 	for _, flag := range opts.Cmd {
 		if strings.Contains(flag, "certificatesresolvers") {
-			t.Errorf("a certificate resolver was configured with no contact address: %q", flag)
+			t.Errorf("a certificate resolver was configured with no domain: %q", flag)
 		}
 		if strings.Contains(flag, "redirections") {
 			t.Errorf("plain HTTP is redirected to a port that cannot serve: %q", flag)
@@ -577,16 +577,32 @@ func TestTraefikWithoutAnACMEEmailHasNoResolver(t *testing.T) {
 	}
 }
 
-// Adding the contact address changes the options, which is what makes
-// Ensure replace the container — a resolver cannot be added to a running
+// Setting a domain changes the options, which is what makes Ensure
+// replace the container — a resolver cannot be added to a running
 // Traefik.
 func TestConfiguringTLSChangesTheTraefikContainer(t *testing.T) {
 	const image = "sha256:same"
-	without := configHash(TraefikContainerOpts(testConfig(), ""), image)
-	with := configHash(TraefikContainerOpts(testConfig(), "admin@example.com"), image)
+	without := configHash(TraefikContainerOpts(testConfig(), false, ""), image)
+	with := configHash(TraefikContainerOpts(testConfig(), true, "admin@example.com"), image)
 
 	if without == with {
-		t.Fatal("configuring a contact address left the container unchanged, so TLS would never take effect")
+		t.Fatal("configuring a domain left the container unchanged, so TLS would never take effect")
+	}
+}
+
+// A contact address is a courtesy, not a condition: Let's Encrypt opens
+// an account without one, so a domain alone must bring the resolver up,
+// and the email flag appears only when there is an address to put in it.
+func TestTLSNeedsNoContactAddress(t *testing.T) {
+	opts := TraefikContainerOpts(testConfig(), true, "")
+
+	if !slices.Contains(opts.Cmd, "--certificatesresolvers.letsencrypt.acme.tlschallenge=true") {
+		t.Error("a domain without a contact address got no certificate resolver")
+	}
+	for _, flag := range opts.Cmd {
+		if strings.HasPrefix(flag, "--certificatesresolvers.letsencrypt.acme.email=") {
+			t.Errorf("an empty contact address was passed to Traefik: %q", flag)
+		}
 	}
 }
 
@@ -630,7 +646,7 @@ func TestAddressesFollowWhereTheDaemonRuns(t *testing.T) {
 // that it does not work at all on Docker Desktop — and nothing needs it
 // now.
 func TestTraefikIsOnTheSharedNetwork(t *testing.T) {
-	opts := TraefikContainerOpts(testConfig(), "admin@example.com")
+	opts := TraefikContainerOpts(testConfig(), true, "admin@example.com")
 
 	if opts.HostNetwork {
 		t.Error("Traefik is still on the host's network")

--- a/internal/platform/bootstrap/bootstrap_test.go
+++ b/internal/platform/bootstrap/bootstrap_test.go
@@ -834,3 +834,20 @@ func TestANewTokenCertificateReplacesTheRegistry(t *testing.T) {
 		t.Error("the container does not record which trust root it was started with")
 	}
 }
+
+// On the host the daemon is not root, and the socket buildkitd creates
+// as root would be one it cannot open. In its container it is root and
+// nothing needs saying.
+func TestBuildKitSocketIsReachableByAHostDaemon(t *testing.T) {
+	cfg := testConfig()
+	cfg.InContainer = false
+	host := BuildKitContainerOpts(cfg)
+	if !slices.Contains(host.Cmd, "--group") {
+		t.Errorf("a host daemon's buildkitd does not hand its socket to the daemon's group: %v", host.Cmd)
+	}
+
+	cfg.InContainer = true
+	if got := BuildKitContainerOpts(cfg).Cmd; len(got) != 0 {
+		t.Errorf("a containerised daemon passes buildkitd flags it does not need: %v", got)
+	}
+}

--- a/internal/platform/dockerx/containers.go
+++ b/internal/platform/dockerx/containers.go
@@ -110,8 +110,13 @@ func (c *Client) PullImage(ctx context.Context, ref string, creds *RegistryAuth)
 	return nil
 }
 
-// authForRef mints a fresh identity token for the registry host of ref,
-// if a signer is registered for it. The host is the segment before the
+// authForRef mints a fresh bearer token for the registry host of ref,
+// if a signer is registered for it. It goes in RegistryToken, which the
+// Engine sends to the registry as is; IdentityToken is not that — it is
+// an OAuth refresh token the Engine takes to the token realm first,
+// which for this registry is the public API through Traefik: a hairpin
+// that needs the domain to resolve and the proxy to be up before the
+// daemon can pull from a registry on its own loopback. The host is the segment before the
 // first "/"; a reference with no "/" (e.g. "registry:2") is a Docker
 // Hub official image and never carries credentials here. The token is
 // scoped to exactly the repository being pulled (everything between the
@@ -165,7 +170,7 @@ func (c *Client) authForRef(ref string) (registry.AuthConfig, bool, error) {
 	if err != nil {
 		return registry.AuthConfig{}, false, err
 	}
-	return registry.AuthConfig{IdentityToken: token, ServerAddress: host}, true, nil
+	return registry.AuthConfig{RegistryToken: token, ServerAddress: host}, true, nil
 }
 
 // LoadImage imports an image tarball into the Engine's own store, which

--- a/internal/platform/dockerx/containers_test.go
+++ b/internal/platform/dockerx/containers_test.go
@@ -412,7 +412,7 @@ func TestPullImageAttachesRegistryAuthForMatchingHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode auth: %v", err)
 	}
-	if decoded.IdentityToken != "signed-jwt" {
+	if decoded.RegistryToken != "signed-jwt" {
 		t.Fatalf("unexpected credentials: %+v", decoded)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -120,7 +120,10 @@ func New(db *database.DB, docker app.DockerAPI, opts Options) *Server {
 
 // WaitForGitHubDeploys blocks until every deploy a GitHub webhook
 // started has finished. For tests.
-func (s *Server) WaitForGitHubDeploys() { s.githubHandler.WaitForDeploys() }
+func (s *Server) WaitForGitHubDeploys() {
+	s.githubHandler.WaitForDeploys()
+	s.Apps.WaitForDeploys()
+}
 
 // SetRegistrySigningKey wires the daemon's registry-token signing key
 // into the registry module. Must be called before serving.

--- a/internal/settings/openapi.go
+++ b/internal/settings/openapi.go
@@ -12,7 +12,7 @@ func (h *Handler) OpenAPI() openapi.Spec {
 		Schemas: map[string]*openapi.Schema{
 			"Settings": openapi.Object(map[string]*openapi.Schema{
 				"domain":               openapi.String("The instance's own name, e.g. cubeship.example.com. The daemon is served at it and the registry at registry.<domain>; both must resolve to this host. A subdomain is what setup offers, because it makes the DNS one A record plus one wildcard rather than a growing list — but nothing enforces the shape. Empty until configured."),
-				"acme_email":           openapi.String("Contact address Let's Encrypt registers for expiry notices. Empty until configured."),
+				"acme_email":           openapi.String("Contact address Let's Encrypt registers. Optional; empty until configured."),
 				"public_ip":            openapi.String("What this instance's DNS records should point at — the operator's answer if they gave one, and otherwise the address on the interface this host reaches the internet through. A browser cannot work this out, which is why it is reported here."),
 				"public_ip_configured": openapi.Bool("Whether the address above was typed rather than detected."),
 				"dns_provider_id":      openapi.String("The stored DNS credential that writes this instance's own records. Empty while its DNS is kept somewhere Cubeship cannot reach."),
@@ -45,7 +45,7 @@ func (h *Handler) OpenAPI() openapi.Spec {
 					Tags: []string{"Instance"},
 					RequestBody: openapi.Body(openapi.Object(map[string]*openapi.Schema{
 						"domain":                openapi.String("The instance's own name, e.g. cubeship.example.com."),
-						"acme_email":            openapi.String("Contact address for Let's Encrypt."),
+						"acme_email":            openapi.String("Contact address for Let's Encrypt. Optional."),
 						"github_client_id":      openapi.String("The App's OAuth client id. Written by the manifest flow; it is what proves who is connecting an installation."),
 						"github_client_secret":  openapi.String("The App's OAuth client secret. Write-only."),
 						"public_ip":             openapi.String("Override what this host believes its own address to be. Empty restores detection."),

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -101,8 +101,8 @@ var ErrSuperAdminOnly = errors.New("forbidden: only a super-admin can change ins
 
 // known is every key this version recognizes, with what it is for.
 var known = map[string]string{
-	Domain:              "Base domain. The API is served at api.<domain> and the registry at registry.<domain>; both must resolve to this host.",
-	ACMEEmail:           "Contact address for Let's Encrypt. Certificates are only issued once this is set.",
+	Domain:              "Base domain. The dashboard and the API are served at <domain> and the registry at registry.<domain>; both must resolve to this host.",
+	ACMEEmail:           "Contact address for Let's Encrypt. Optional: certificates are issued as soon as there is a domain.",
 	PublicIP:            "What this instance's DNS records should point at. Empty means the address on the interface this host reaches the internet through, which is right on a VPS and wrong behind NAT.",
 	DNSProviderID:       "Which stored DNS credential writes this instance's own records. Empty means the operator keeps their DNS elsewhere and writes them by hand.",
 	GitHubAppID:         "The numeric id of the GitHub App this instance acts as.",
@@ -150,11 +150,12 @@ func (v Values) HasGitHubOAuth() bool {
 // possible at all.
 func (v Values) HasDomain() bool { return v[Domain] != "" }
 
-// HasTLS reports whether certificates can be issued. Both a domain and a
-// contact address are needed: Let's Encrypt will not register an account
-// without one, and there is nothing to get a certificate for without the
-// other.
-func (v Values) HasTLS() bool { return v.HasDomain() && v[ACMEEmail] != "" }
+// HasTLS reports whether certificates can be issued, which takes a
+// domain and nothing else: Let's Encrypt registers an account without a
+// contact address, and Traefik passes an empty one through. The address
+// is where expiry notices would go, and Let's Encrypt stopped sending
+// those — it is a courtesy, not a condition.
+func (v Values) HasTLS() bool { return v.HasDomain() }
 
 // The names derived from the base domain. They are computed here rather
 // than stored so that changing the domain changes them everywhere at

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -92,28 +92,29 @@ func TestConfiguringADomainGivesExistingAppsAPushPath(t *testing.T) {
 	}
 }
 
-// Certificates need both: Let's Encrypt will not register an account
-// without a contact address, and there is nothing to certify without a
-// domain.
-func TestTLSNeedsBothADomainAndAContactAddress(t *testing.T) {
+// Certificates need a domain and nothing else: Let's Encrypt opens an
+// account without a contact address, so the address is a courtesy that
+// must not hold TLS back.
+func TestTLSNeedsOnlyADomain(t *testing.T) {
 	f := servertest.NewUnconfigured(t)
+
+	if read(t, f, f.AdminKey).TLSEnabled {
+		t.Error("TLS is claimed with nothing configured")
+	}
 
 	servertest.RequireStatus(t, f.Do(t, http.MethodPut, "/settings",
 		map[string]string{"domain": "example.com"}, f.AdminKey), http.StatusOK)
-	if read(t, f, f.AdminKey).TLSEnabled {
-		t.Error("TLS is claimed with a domain but no contact address")
+	if !read(t, f, f.AdminKey).TLSEnabled {
+		t.Error("TLS is off with a domain and no contact address")
 	}
 
 	servertest.RequireStatus(t, f.Do(t, http.MethodPut, "/settings",
 		map[string]string{"acme_email": "admin@example.com"}, f.AdminKey), http.StatusOK)
 
 	got := read(t, f, f.AdminKey)
-	if !got.TLSEnabled {
-		t.Error("TLS is still off with both configured")
-	}
 	// Setting the email must not have cleared the domain: only the field
 	// sent is changed.
-	if got.Domain != "example.com" {
+	if got.Domain != "example.com" || !got.TLSEnabled {
 		t.Errorf("the domain was lost when the contact address was set: %+v", got)
 	}
 }

--- a/test/install/run.sh
+++ b/test/install/run.sh
@@ -92,6 +92,7 @@ run_tests() {
 	check "publishes the port" "$(grep -c '\-p 3000:3000' /tmp/docker.log)" "1"
 	check "restarts it with the host" \
 		"$(grep -c '\-\-restart unless-stopped' /tmp/docker.log)" "1"
+	check "ends with the name in lights" "$(printf '%s' "$out" | grep -c '██████╗██╗')" "1"
 	check "tells you where to open it" \
 		"$(printf '%s' "$out" | grep -c 'https://203-0-113-7.sslip.io')" "1"
 	check "makes a domain from the public address" \

--- a/test/install/run.sh
+++ b/test/install/run.sh
@@ -45,7 +45,14 @@ setup_stubs() {
 		esac
 		exit 0
 	EOF
-	chmod +x /stub/systemctl /stub/docker
+	# curl stands in for the public-address lookup: the container this
+	# runs in may have no network, and the test wants a known answer.
+	cat > /stub/curl <<-'EOF'
+		#!/bin/sh
+		echo "curl $*" >> /tmp/curl.log
+		echo "203.0.113.7"
+	EOF
+	chmod +x /stub/systemctl /stub/docker /stub/curl
 	PATH="/stub:$PATH"
 	export PATH
 }
@@ -86,7 +93,28 @@ run_tests() {
 	check "restarts it with the host" \
 		"$(grep -c '\-\-restart unless-stopped' /tmp/docker.log)" "1"
 	check "tells you where to open it" \
+		"$(printf '%s' "$out" | grep -c 'https://203-0-113-7.sslip.io')" "1"
+	check "makes a domain from the public address" \
+		"$(grep -c 'CUBESHIP_DOMAIN=203-0-113-7.sslip.io' /tmp/docker.log)" "1"
+	check "keeps the port as the way in until the certificate is up" \
 		"$(printf '%s' "$out" | grep -c ':3000')" "1"
+
+	# A domain given wins over the one made up, and is passed as is.
+	rm -f /tmp/docker.log
+	DOMAIN=cube.example.com main >/dev/null 2>&1
+	check "--domain is passed through" \
+		"$(grep -c 'CUBESHIP_DOMAIN=cube.example.com' /tmp/docker.log)" "1"
+	DOMAIN=""
+
+	# A lookup that fails is an install with no domain, not a failed one.
+	rm -f /tmp/docker.log
+	printf '#!/bin/sh\nexit 22\n' > /stub/curl
+	out=$(main 2>&1) || { printf '%s\n' "$out"; exit 1; }
+	check "no public address means no domain" \
+		"$(grep -c 'CUBESHIP_DOMAIN= ' /tmp/docker.log)" "1"
+	check "and says where to open instead" \
+		"$(printf '%s' "$out" | grep -c 'http://.*:3000')" "1"
+	printf '#!/bin/sh\necho 203.0.113.7\n' > /stub/curl
 
 	# The data directory has to be mounted at the same path inside as
 	# outside: the daemon hands these paths to the Engine for its

--- a/test/install/run.sh
+++ b/test/install/run.sh
@@ -83,7 +83,7 @@ run_tests() {
 	out=$(main 2>&1) || { printf '%s\n' "$out"; exit 1; }
 
 	check "creates the data directory" "$(stat -c '%a' /var/lib/cubeship)" "700"
-	check "pulls the image" "$(grep -c '^docker pull ' /tmp/docker.log)" "1"
+	check "pulls both images" "$(grep -c '^docker pull ' /tmp/docker.log)" "2"
 	check "creates the shared network" \
 		"$(grep -c '^docker network create cubeship' /tmp/docker.log)" "1"
 	check "runs the daemon" "$(grep -c 'docker run .*--name cubeship-daemon' /tmp/docker.log)" "1"
@@ -129,16 +129,16 @@ run_tests() {
 	rm -f /tmp/docker.log
 	touch /src/Dockerfile
 	LOCAL=1
-	build_image
-	check "--local builds the image" "$(grep -c '^docker build ' /tmp/docker.log)" "1"
+	build_images
+	check "--local builds both images" "$(grep -c '^docker build ' /tmp/docker.log)" "2"
 	check "--local does not pull" "$(grep -c '^docker pull ' /tmp/docker.log)" "0"
-	check "--local builds from the checkout" "$(grep -c ' /src$' /tmp/docker.log)" "1"
+	check "--local builds from the checkout" "$(grep -c ' /src$' /tmp/docker.log)" "2"
 	LOCAL=0
 
 	# Piped from curl there is no checkout, and --local cannot serve
 	# that. Saying so beats a build that fails on a missing Dockerfile.
 	rm -f /src/Dockerfile
-	if (LOCAL=1; build_image) >/dev/null 2>&1; then
+	if (LOCAL=1; build_images) >/dev/null 2>&1; then
 		printf '  FAIL --local built with no repository present\n'
 		FAILURES=$((FAILURES + 1))
 	else

--- a/test/integration/build_test.go
+++ b/test/integration/build_test.go
@@ -182,11 +182,17 @@ func apiRequest(t *testing.T, method, path, apiKey string, body string) *http.Re
 	return resp
 }
 
+// createApp creates an app and, when fields names a "domain", adds it
+// afterwards: an app is created empty and a domain is its own resource,
+// and without one a deploy is refused.
 func createApp(t *testing.T, apiKey string, fields map[string]string) string {
 	t.Helper()
+	domain := fields["domain"]
 	var parts []string
 	for k, v := range fields {
-		parts = append(parts, fmt.Sprintf("%q:%q", k, v))
+		if k != "domain" {
+			parts = append(parts, fmt.Sprintf("%q:%q", k, v))
+		}
 	}
 	resp := apiRequest(t, http.MethodPost, "/apps", apiKey, "{"+strings.Join(parts, ",")+"}")
 	defer resp.Body.Close()
@@ -197,6 +203,15 @@ func createApp(t *testing.T, apiKey string, fields map[string]string) string {
 		Reference string `json:"reference"`
 	}
 	jsonDecodeOrFatal(t, resp, &created)
+
+	if domain != "" {
+		resp := apiRequest(t, http.MethodPost, "/apps/"+created.Reference+"/domains", apiKey,
+			fmt.Sprintf(`{"host":%q}`, domain))
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+			t.Fatalf("add domain: %s", resp.Status)
+		}
+	}
 	return created.Reference
 }
 

--- a/test/integration/build_test.go
+++ b/test/integration/build_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/cgi"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -156,13 +157,25 @@ func serveRepo(t *testing.T, files map[string]string) string {
 	git(work, "clone", "--quiet", "--bare", work, bare)
 	git(bare, "--git-dir", bare, "update-server-info")
 
+	// Served over git's smart protocol: BuildKit's git would cope with a
+	// plain file server, but the daemon clones with go-git for a
+	// Railpack build, and go-git speaks smart HTTP only.
+	backend := filepath.Join(strings.TrimSpace(gitExecPath(t)), "git-http-backend")
+	if _, err := os.Stat(backend); err != nil {
+		t.Fatalf("git-http-backend is not installed: %v", err)
+	}
+	handler := &cgi.Handler{
+		Path: backend,
+		Env:  []string{"GIT_PROJECT_ROOT=" + serveDir, "GIT_HTTP_EXPORT_ALL=1"},
+	}
+
 	// The builder is a container reaching back to this process, and a
 	// Railpack build clones in the daemon: see hostAddress.
 	l, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv := httptest.NewUnstartedServer(http.FileServer(http.Dir(serveDir)))
+	srv := httptest.NewUnstartedServer(handler)
 	srv.Listener = l
 	srv.Start()
 	t.Cleanup(srv.Close)
@@ -270,4 +283,13 @@ func appStatus(t *testing.T, apiKey, reference string) string {
 	}
 	jsonDecodeOrFatal(t, resp, &a)
 	return a.Status
+}
+
+func gitExecPath(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("git", "--exec-path").Output()
+	if err != nil {
+		t.Fatalf("git --exec-path: %v", err)
+	}
+	return string(out)
 }

--- a/test/integration/build_test.go
+++ b/test/integration/build_test.go
@@ -156,15 +156,22 @@ func serveRepo(t *testing.T, files map[string]string) string {
 	git(work, "clone", "--quiet", "--bare", work, bare)
 	git(bare, "--git-dir", bare, "update-server-info")
 
-	srv := httptest.NewServer(http.FileServer(http.Dir(serveDir)))
+	// The builder is a container reaching back to this process, and a
+	// Railpack build clones in the daemon: see hostAddress.
+	l, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewUnstartedServer(http.FileServer(http.Dir(serveDir)))
+	srv.Listener = l
+	srv.Start()
 	t.Cleanup(srv.Close)
 
-	// The builder is a container reaching back to this process.
 	_, port, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	return "http://host.docker.internal:" + port + "/repo.git"
+	return "http://" + hostAddress(t) + ":" + port + "/repo.git"
 }
 
 func apiRequest(t *testing.T, method, path, apiKey string, body string) *http.Response {

--- a/test/integration/builder_test.go
+++ b/test/integration/builder_test.go
@@ -306,11 +306,19 @@ func gitRepo(t *testing.T, files map[string]string) string {
 		t.Fatalf("update-server-info: %v\n%s", err, out)
 	}
 
-	srv := httptest.NewServer(http.FileServer(http.Dir(filepath.Dir(bare))))
+	// The builder is a container, so it reaches this server by the
+	// host's gateway rather than by the loopback the test sees — which
+	// on Linux is a different interface, so the server must listen on
+	// all of them. httptest's default is loopback only.
+	l, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewUnstartedServer(http.FileServer(http.Dir(filepath.Dir(bare))))
+	srv.Listener = l
+	srv.Start()
 	t.Cleanup(srv.Close)
 
-	// The builder is a container, so it reaches this server by the
-	// host's gateway rather than by the loopback the test sees.
 	_, port, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/builder_test.go
+++ b/test/integration/builder_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -323,7 +324,26 @@ func gitRepo(t *testing.T, files map[string]string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return "http://host.docker.internal:" + port + "/repo.git"
+	return "http://" + hostAddress(t) + ":" + port + "/repo.git"
+}
+
+// hostAddress is where a container reaches this test's servers, and
+// where the daemon on the host reaches them too — a Railpack build
+// clones in the daemon, so the address has to work from both sides.
+// Docker Desktop resolves host.docker.internal on the Mac itself; a
+// Linux host does not, and there the bridge gateway is an address of
+// the host that both sides share.
+func hostAddress(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		return "host.docker.internal"
+	}
+	out, err := exec.Command("docker", "network", "inspect", "bridge",
+		"-f", "{{(index .IPAM.Config 0).Gateway}}").Output()
+	if err != nil {
+		t.Fatalf("docker network inspect bridge: %v", err)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // End to end: a repository with no Dockerfile becomes an image that

--- a/test/integration/deploy_test.go
+++ b/test/integration/deploy_test.go
@@ -134,11 +134,12 @@ func TestDeployEndToEnd(t *testing.T) {
 		exec.Command("docker", "rm", "-f", "cubeship-registry", "cubeship-traefik",
 			"cubeship-postgres", "cubeship-frontend", "cubeship-buildkit").Run()
 		exec.Command("sh", "-c", "docker rm -f $(docker ps -aq --filter name=cubeship-web-production-myapp-)").Run()
-		// Postgres wrote its data directory as its own user, which the
-		// TempDir cleanup cannot remove — and a cleanup that fails fails
-		// the test. Its image is already here, so it does the chmod.
-		exec.Command("docker", "run", "--rm", "-v", dataDir+":/d", "--entrypoint", "chmod",
-			"postgres:16-alpine", "-R", "a+rwX", "/d").Run()
+		// Postgres and BuildKit wrote the data directory as root, with
+		// sticky bits the TempDir cleanup cannot get past — and a cleanup
+		// that fails fails the test. A root inside a container empties
+		// it; the Postgres image is already here.
+		exec.Command("docker", "run", "--rm", "-v", dataDir+":/d", "--entrypoint", "sh",
+			"postgres:16-alpine", "-c", "rm -rf /d/* /d/.[!.]*").Run()
 	})
 
 	waitFor(t, 30*time.Second, "daemon healthz", func() bool {

--- a/test/integration/deploy_test.go
+++ b/test/integration/deploy_test.go
@@ -116,8 +116,14 @@ func TestDeployEndToEnd(t *testing.T) {
 	t.Cleanup(func() {
 		daemon.Process.Kill()
 		daemon.Wait()
-		exec.Command("docker", "rm", "-f", "cubeship-registry", "cubeship-traefik").Run()
+		exec.Command("docker", "rm", "-f", "cubeship-registry", "cubeship-traefik",
+			"cubeship-postgres", "cubeship-frontend", "cubeship-buildkit").Run()
 		exec.Command("sh", "-c", "docker rm -f $(docker ps -aq --filter name=cubeship-myapp-)").Run()
+		// Postgres wrote its data directory as its own user, which the
+		// TempDir cleanup cannot remove — and a cleanup that fails fails
+		// the test. Its image is already here, so it does the chmod.
+		exec.Command("docker", "run", "--rm", "-v", dataDir+":/d", "--entrypoint", "chmod",
+			"postgres:16-alpine", "-R", "a+rwX", "/d").Run()
 	})
 
 	waitFor(t, 30*time.Second, "daemon healthz", func() bool {
@@ -301,7 +307,7 @@ func claimInstance(t *testing.T, username, password string) string {
 		t.Fatalf("POST /users/me/api-keys: %s", keyResp.Status)
 	}
 	var created struct {
-		Key string `json:"key"`
+		Key string `json:"api_key"`
 	}
 	jsonDecodeOrFatal(t, keyResp, &created)
 	if created.Key == "" {

--- a/test/integration/deploy_test.go
+++ b/test/integration/deploy_test.go
@@ -114,6 +114,17 @@ func TestDeployEndToEnd(t *testing.T) {
 		t.Fatalf("start daemon: %v", err)
 	}
 	t.Cleanup(func() {
+		// What the daemon's own log cannot say: how the proxy and the
+		// registry saw the requests that failed.
+		if t.Failed() {
+			for _, name := range []string{"cubeship-traefik", "cubeship-registry"} {
+				out, _ := exec.Command("docker", "logs", "--tail", "60", name).CombinedOutput()
+				t.Logf("---- docker logs %s ----\n%s", name, out)
+			}
+			out, _ := exec.Command("curl", "-sk", "-o", "/dev/null", "-w", "%{http_code} %{redirect_url}",
+				"https://localtest.me/v2/token").CombinedOutput()
+			t.Logf("---- curl https://localtest.me/v2/token: %s", out)
+		}
 		daemon.Process.Kill()
 		daemon.Wait()
 		exec.Command("docker", "rm", "-f", "cubeship-registry", "cubeship-traefik",

--- a/test/integration/deploy_test.go
+++ b/test/integration/deploy_test.go
@@ -104,7 +104,6 @@ func TestDeployEndToEnd(t *testing.T) {
 	daemon := exec.Command(daemonBin)
 	daemon.Env = append(os.Environ(),
 		"CUBESHIP_DOMAIN=localtest.me",
-		"CUBESHIP_ACME_EMAIL=test@example.com",
 		"CUBESHIP_TOKEN="+testToken,
 		"CUBESHIP_DATA_DIR="+dataDir,
 	)

--- a/test/integration/deploy_test.go
+++ b/test/integration/deploy_test.go
@@ -101,6 +101,7 @@ func TestDeployEndToEnd(t *testing.T) {
 	}
 
 	dataDir := t.TempDir()
+	var adminKey string
 	daemon := exec.Command(daemonBin)
 	daemon.Env = append(os.Environ(),
 		"CUBESHIP_DOMAIN=localtest.me",
@@ -120,9 +121,13 @@ func TestDeployEndToEnd(t *testing.T) {
 				out, _ := exec.Command("docker", "logs", "--tail", "60", name).CombinedOutput()
 				t.Logf("---- docker logs %s ----\n%s", name, out)
 			}
-			out, _ := exec.Command("curl", "-sk", "-o", "/dev/null", "-w", "%{http_code} %{redirect_url}",
-				"https://localtest.me/v2/token").CombinedOutput()
-			t.Logf("---- curl https://localtest.me/v2/token: %s", out)
+			out, _ := exec.Command("sh", "-c", "docker ps -a --filter name=cubeship- --format '{{.Names}}\t{{.Status}}\t{{.Image}}'").CombinedOutput()
+			t.Logf("---- docker ps -a ----\n%s", out)
+			out, _ = exec.Command("sh", "-c", "docker logs --tail 20 $(docker ps -aq --filter name=cubeship-myapp-) 2>&1").CombinedOutput()
+			t.Logf("---- app container logs ----\n%s", out)
+			out, _ = exec.Command("curl", "-s", "-H", "Authorization: Bearer "+adminKey,
+				daemonURL+httpx.APIPrefix+"/apps/myapp/deployments").CombinedOutput()
+			t.Logf("---- deployments ----\n%s", out)
 		}
 		daemon.Process.Kill()
 		daemon.Wait()
@@ -160,7 +165,7 @@ func TestDeployEndToEnd(t *testing.T) {
 	// CUBESHIP_TOKEN is the registry/webhook credential only. A fresh
 	// instance has no account at all: the first request anyone makes
 	// claims it, exactly as a browser would on the setup page.
-	adminKey := claimInstance(t, adminUsername, adminPassword)
+	adminKey = claimInstance(t, adminUsername, adminPassword)
 	client := client.New(daemonURL, adminKey)
 
 	if _, err := client.CreateProject(ctx, "web"); err != nil {

--- a/test/integration/deploy_test.go
+++ b/test/integration/deploy_test.go
@@ -123,17 +123,17 @@ func TestDeployEndToEnd(t *testing.T) {
 			}
 			out, _ := exec.Command("sh", "-c", "docker ps -a --filter name=cubeship- --format '{{.Names}}\t{{.Status}}\t{{.Image}}'").CombinedOutput()
 			t.Logf("---- docker ps -a ----\n%s", out)
-			out, _ = exec.Command("sh", "-c", "docker logs --tail 20 $(docker ps -aq --filter name=cubeship-myapp-) 2>&1").CombinedOutput()
+			out, _ = exec.Command("sh", "-c", "docker logs --tail 20 $(docker ps -aq --filter name=cubeship-web-production-myapp-) 2>&1").CombinedOutput()
 			t.Logf("---- app container logs ----\n%s", out)
 			out, _ = exec.Command("curl", "-s", "-H", "Authorization: Bearer "+adminKey,
-				daemonURL+httpx.APIPrefix+"/apps/myapp/deployments").CombinedOutput()
+				daemonURL+httpx.APIPrefix+"/apps/web/production/myapp/deployments").CombinedOutput()
 			t.Logf("---- deployments ----\n%s", out)
 		}
 		daemon.Process.Kill()
 		daemon.Wait()
 		exec.Command("docker", "rm", "-f", "cubeship-registry", "cubeship-traefik",
 			"cubeship-postgres", "cubeship-frontend", "cubeship-buildkit").Run()
-		exec.Command("sh", "-c", "docker rm -f $(docker ps -aq --filter name=cubeship-myapp-)").Run()
+		exec.Command("sh", "-c", "docker rm -f $(docker ps -aq --filter name=cubeship-web-production-myapp-)").Run()
 		// Postgres wrote its data directory as its own user, which the
 		// TempDir cleanup cannot remove — and a cleanup that fails fails
 		// the test. Its image is already here, so it does the chmod.
@@ -212,7 +212,7 @@ func TestDeployEndToEnd(t *testing.T) {
 	}
 
 	waitFor(t, 60*time.Second, "app deployed after push", func() bool {
-		req, _ := http.NewRequest(http.MethodGet, daemonURL+httpx.APIPrefix+"/apps/myapp", nil)
+		req, _ := http.NewRequest(http.MethodGet, daemonURL+httpx.APIPrefix+"/apps/web/production/myapp", nil)
 		req.Header.Set("Authorization", "Bearer "+adminKey)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {

--- a/web/src/components/instance-domain.tsx
+++ b/web/src/components/instance-domain.tsx
@@ -168,7 +168,7 @@ export function InstanceDomain({
   }
 
   const automatic = Boolean(providerID);
-  const ready = Boolean(domain && email && (!automatic || (zoneID && ip)));
+  const ready = Boolean(domain && (!automatic || (zoneID && ip)));
 
   return (
     <>
@@ -262,7 +262,7 @@ export function InstanceDomain({
               placeholder="you@example.com"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              hint="Where expiry warnings go. Certificates are only issued once this is set — it is the one thing here nothing can work out for you."
+              hint="Optional. Let's Encrypt registers it with the account; certificates are issued with or without one."
             />
           </div>
 


### PR DESCRIPTION
A fresh install answers at `https://<a-b-c-d>.sslip.io` instead of `http://<ip>:3000`.

- `install.sh` asks `api.ipify.org`, then `ifconfig.me`, then `icanhazip.com` for the public address and passes `CUBESHIP_DOMAIN=<a-b-c-d>.sslip.io` to the daemon. `--domain` / `CUBESHIP_DOMAIN` overrides it. No answer means no domain and the old banner.
- The Let's Encrypt contact address is optional: `HasTLS` is `HasDomain`, `TraefikContainerOpts` takes `tls` and passes the email flag only when given. Traefik 3.1's ACME provider and lego open an account without a contact.
- Dashboard no longer requires the email to submit; README, OpenAPI and CLAUDE.md say so.

While the daemon boots, the installer now streams its `bootstrap:` lines (which image is being pulled, which container started) instead of a bare "Waiting for the daemon", allows ten minutes for it, and ends with CUBESHIP in block letters.

Not run locally: the DB-backed `TestTLSNeedsOnlyADomain` and `make test-install` (Linux). CI runs both.

Test:

```sh
make check && make test-db && make test-install
```

Or on a throwaway VPS with 80/443 open:

```sh
sh install.sh --local
```

and open the printed `https://<ip-dashes>.sslip.io`; the certificate should issue on the first visit.