### PR TITLE
Take a page's params from Next's route types, and stop asking for /apps/undefined/...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,5 +102,9 @@ jobs:
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec biome ci .
-      - run: pnpm exec tsc --noEmit
+      # typegen first: the pages take their params from Next's generated
+      # route types, so a segment renamed without the page following it
+      # is a type error rather than an undefined glued into a URL. Those
+      # types do not exist in a fresh checkout.
+      - run: pnpm run typecheck
       - run: pnpm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,17 @@ on the host proxies there rather than to a container —
 `bootstrap.FrontendAddress` is the one place that branches. Reaching
 :3001 directly works too; it rewrites `/api` to the daemon.
 
+**A page's params come from Next's generated route types**, not from a
+hand-written one: `PageProps<"/projects/[project]/[env]/[app]">` reads
+the segments the directory actually has, so a segment renamed without
+the page following it is a type error. A hand-written type is how a page
+went on destructuring `org` after organizations were removed and asked
+the daemon for `/apps/undefined/<project>/<env>/<app>` — which answers
+"no such endpoint", at the address the dashboard sends you to after
+creating something. Those generated types do not exist in a fresh
+checkout, so `pnpm typecheck` writes them first; CI runs that before the
+build.
+
 Package manager is **pnpm** (`pnpm-lock.yaml` is the lockfile the image
 build installs from, along with `pnpm-workspace.yaml`, which carries the
 settings that install is governed by), and linting and formatting are both **Biome** —

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "biome check",
+    "typecheck": "next typegen && tsc --noEmit",
     "format": "biome check --write"
   },
   "dependencies": {

--- a/web/src/app/(dashboard)/dns/[id]/page.tsx
+++ b/web/src/app/(dashboard)/dns/[id]/page.tsx
@@ -28,7 +28,7 @@ import { message } from "@/lib/errors";
 // could do: there was no route to send you to. A zone holds tens or
 // hundreds of records and is the thing you actually work in, so it is a
 // page of its own — reachable by a link you can send someone.
-export default function DNSZones({ params }: { params: Promise<{ id: string }> }) {
+export default function DNSZones({ params }: PageProps<"/dns/[id]">) {
   const { id } = use(params);
 
   const [credential, setCredential] = useState<DNSCredential | null>(null);

--- a/web/src/app/(dashboard)/dns/[id]/settings/page.tsx
+++ b/web/src/app/(dashboard)/dns/[id]/settings/page.tsx
@@ -27,7 +27,7 @@ import { message } from "@/lib/errors";
 // how it authenticates and what its secret even is both follow from
 // that — so changing it in place would not be an edit, it would be a
 // different credential wearing the old one's id.
-export default function DNSSettings({ params }: { params: Promise<{ id: string }> }) {
+export default function DNSSettings({ params }: PageProps<"/dns/[id]/settings">) {
   const { id } = use(params);
   const router = useRouter();
 

--- a/web/src/app/(dashboard)/dns/[id]/zones/[zone]/page.tsx
+++ b/web/src/app/(dashboard)/dns/[id]/zones/[zone]/page.tsx
@@ -36,7 +36,7 @@ import { message } from "@/lib/errors";
 // is unique within an account either way. The id is what every call
 // needs, so it is resolved from the zone listing on arrival — one extra
 // request, in exchange for a URL that says what it is.
-export default function ZoneRecords({ params }: { params: Promise<{ id: string; zone: string }> }) {
+export default function ZoneRecords({ params }: PageProps<"/dns/[id]/zones/[zone]">) {
   const { id, zone: zoneName } = use(params);
   const name = decodeURIComponent(zoneName);
   const queries = useQueryClient();

--- a/web/src/app/(dashboard)/projects/[project]/[env]/[app]/page.tsx
+++ b/web/src/app/(dashboard)/projects/[project]/[env]/[app]/page.tsx
@@ -19,13 +19,14 @@ import { message } from "@/lib/errors";
 // it means anything. `gateway` is unique in acme/api/production and
 // nowhere else, so the URL is the reference and the reference is the
 // URL.
-export default function AppPage({
-  params,
-}: {
-  params: Promise<{ org: string; project: string; env: string; app: string }>;
-}) {
-  const { org, project, env, app } = use(params);
-  return <Detail reference={`${org}/${project}/${env}/${app}`} />;
+// PageProps comes from Next's generated route types, so the params this
+// destructures are the segments the directory actually has. Spelling one
+// that is not there is a build error rather than an `undefined` glued
+// into the reference — which is how this page once asked the daemon for
+// /apps/undefined/<project>/<env>/<app> and got "no such endpoint".
+export default function AppPage({ params }: PageProps<"/projects/[project]/[env]/[app]">) {
+  const { project, env, app } = use(params);
+  return <Detail reference={`${project}/${env}/${app}`} />;
 }
 
 function Detail({ reference }: { reference: string }) {

--- a/web/src/app/(dashboard)/projects/[project]/[env]/[app]/settings/page.tsx
+++ b/web/src/app/(dashboard)/projects/[project]/[env]/[app]/settings/page.tsx
@@ -32,11 +32,9 @@ const SOURCE: Record<Origin, Record<string, AppSource>> = {
 
 export default function AppSettingsPage({
   params,
-}: {
-  params: Promise<{ org: string; project: string; env: string; app: string }>;
-}) {
-  const { org, project, env, app } = use(params);
-  return <Settings reference={`${org}/${project}/${env}/${app}`} />;
+}: PageProps<"/projects/[project]/[env]/[app]/settings">) {
+  const { project, env, app } = use(params);
+  return <Settings reference={`${project}/${env}/${app}`} />;
 }
 
 function Settings({ reference }: { reference: string }) {

--- a/web/src/app/(dashboard)/projects/[project]/[env]/page.tsx
+++ b/web/src/app/(dashboard)/projects/[project]/[env]/page.tsx
@@ -26,15 +26,10 @@ import { message } from "@/lib/errors";
 
 // One project, opened on an environment.
 //
-// The organization is in the path even though it is never in the
-// sidebar's URLs: a link has to work for someone whose sidebar is
-// pointing elsewhere, and opening one moves the whole dashboard there
-// rather than showing a page out of frame.
-export default function ProjectPage({
-  params,
-}: {
-  params: Promise<{ project: string; env: string }>;
-}) {
+// The environment is in the path rather than in a tab's state: it is
+// what identifies the apps below it, so a link someone sends opens the
+// same screen they were looking at.
+export default function ProjectPage({ params }: PageProps<"/projects/[project]/[env]">) {
   return <Detail {...use(params)} />;
 }
 

--- a/web/src/app/(dashboard)/projects/[project]/[env]/settings/page.tsx
+++ b/web/src/app/(dashboard)/projects/[project]/[env]/settings/page.tsx
@@ -23,15 +23,12 @@ const PRODUCTION = "production";
 
 export default function EnvironmentSettingsPage({
   params,
-}: {
-  params: Promise<{ org: string; project: string; env: string }>;
-}) {
+}: PageProps<"/projects/[project]/[env]/settings">) {
   return <Settings {...use(params)} />;
 }
 
-function Settings({ org, project, env }: { org: string; project: string; env: string }) {
+function Settings({ project, env }: { project: string; env: string }) {
   const router = useRouter();
-  const ref = `${org}/${project}/${env}`;
 
   const [current, setCurrent] = useState<Environment | null>(null);
   const [description, setDescription] = useState("");
@@ -46,7 +43,7 @@ function Settings({ org, project, env }: { org: string; project: string; env: st
   // There is no "get one environment" endpoint — the list is the read,
   // and a project holds a handful of them.
   useEffect(() => {
-    if (project || !env) return;
+    if (!project || !env) return;
     api
       .get<Environment[]>(`${projectPath}/environments`)
       .then((list) => {
@@ -58,7 +55,7 @@ function Settings({ org, project, env }: { org: string; project: string; env: st
       .catch((e) => setError(message(e)));
   }, [projectPath, project, env]);
 
-  if (!ref || !env) {
+  if (!project || !env) {
     return (
       <p className="text-sm text-muted-foreground">
         No environment named.{" "}
@@ -94,7 +91,7 @@ function Settings({ org, project, env }: { org: string; project: string; env: st
         className="mb-4 inline-flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-primary"
       >
         <ChevronLeftIcon className="size-3.5" />
-        {org}/{project}/{env}
+        {project}/{env}
       </Link>
 
       <PageHeader
@@ -121,7 +118,7 @@ function Settings({ org, project, env }: { org: string; project: string; env: st
             <div className="space-y-2">
               <Label className="text-xs text-muted-foreground">Slug</Label>
               <div className="flex h-10 items-center border border-border bg-secondary/40 px-3 font-mono text-sm text-muted-foreground">
-                {org}/{project}/{env}
+                {project}/{env}
               </div>
               <p className="text-xs text-subtle-foreground">
                 Not editable. It is the third component of every app reference in this environment.

--- a/web/src/app/(dashboard)/projects/[project]/page.tsx
+++ b/web/src/app/(dashboard)/projects/[project]/page.tsx
@@ -6,7 +6,7 @@ import { redirect } from "next/navigation";
 // "a project's apps" instead of two that have to stay identical — and so
 // the address bar says which environment you are looking at even when
 // you did not pick one.
-export default async function Project({ params }: { params: Promise<{ project: string }> }) {
+export default async function Project({ params }: PageProps<"/projects/[project]">) {
   const { project } = await params;
   redirect(`/projects/${project}/production`);
 }

--- a/web/src/app/(dashboard)/projects/[project]/settings/page.tsx
+++ b/web/src/app/(dashboard)/projects/[project]/settings/page.tsx
@@ -16,17 +16,12 @@ import { Label } from "@/components/ui/label";
 import { api, type Project } from "@/lib/api";
 import { message } from "@/lib/errors";
 
-export default function ProjectSettingsPage({
-  params,
-}: {
-  params: Promise<{ org: string; project: string }>;
-}) {
+export default function ProjectSettingsPage({ params }: PageProps<"/projects/[project]/settings">) {
   return <Settings {...use(params)} />;
 }
 
-function Settings({ org, project }: { org: string; project: string }) {
+function Settings({ project }: { project: string }) {
   const router = useRouter();
-  const ref = `${org}/${project}`;
 
   const [current, setCurrent] = useState<Project | null>(null);
   const [description, setDescription] = useState("");
@@ -40,7 +35,7 @@ function Settings({ org, project }: { org: string; project: string }) {
   // There is no "get one project" endpoint — the list is the read, and
   // on a single-VPS install it is a handful of rows.
   useEffect(() => {
-    if (project) return;
+    if (!project) return;
     api
       .get<Project[]>(`/projects`)
       .then((list) => {
@@ -52,7 +47,7 @@ function Settings({ org, project }: { org: string; project: string }) {
       .catch((e) => setError(message(e)));
   }, [project]);
 
-  if (!ref || !project) {
+  if (!project) {
     return (
       <p className="text-sm text-muted-foreground">
         No project named.{" "}
@@ -89,7 +84,7 @@ function Settings({ org, project }: { org: string; project: string }) {
         className="mb-4 inline-flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-primary"
       >
         <ChevronLeftIcon className="size-3.5" />
-        {org}/{project}
+        {project}
       </Link>
 
       <PageHeader title="Project settings" sub="What this project is called, and what it is for." />
@@ -113,7 +108,7 @@ function Settings({ org, project }: { org: string; project: string }) {
             <div className="space-y-2">
               <Label className="text-xs text-muted-foreground">Slug</Label>
               <div className="flex h-10 items-center border border-border bg-secondary/40 px-3 font-mono text-sm text-muted-foreground">
-                {org}/{project}
+                {project}
               </div>
               <p className="text-xs text-subtle-foreground">
                 Not editable. It is a path component of every app&apos;s registry reference under

--- a/web/src/app/(dashboard)/registries/[id]/page.tsx
+++ b/web/src/app/(dashboard)/registries/[id]/page.tsx
@@ -38,7 +38,7 @@ import { message } from "@/lib/errors";
 // own has no credential — a push authenticates with the pusher's API key
 // — so it is addressed as the organization's registry rather than by an
 // id. Everything below the fetch is the same either way.
-export default function RegistryDetail({ params }: { params: Promise<{ id: string }> }) {
+export default function RegistryDetail({ params }: PageProps<"/registries/[id]">) {
   const { id } = use(params);
   // "cubeship" is the reserved name for the one registry this instance
   // runs. Every other id is a stored credential's, which is a number, so

--- a/web/src/app/(dashboard)/registries/[id]/settings/page.tsx
+++ b/web/src/app/(dashboard)/registries/[id]/settings/page.tsx
@@ -29,7 +29,7 @@ import { message } from "@/lib/errors";
 // This is also where a registry that has stopped accepting its login
 // lands when you click it, because re-authenticating is the only thing
 // there is to do with one.
-export default function RegistrySettings({ params }: { params: Promise<{ id: string }> }) {
+export default function RegistrySettings({ params }: PageProps<"/registries/[id]/settings">) {
   const { id } = use(params);
   const router = useRouter();
 


### PR DESCRIPTION
Opening an app — which is where creating one lands you — answered `no such endpoint`.

## What was wrong

The app page still destructured `org` from its params after organizations were removed, so its reference came out as `undefined/<project>/<env>/<app>` and it asked the daemon for `/api/apps/undefined/octokube/production/octokube-server`. That is one segment more than `GET /apps/{project}/{env}/{name}`, matches no route, and the daemon answers with exactly that message (`internal/server/server.go`).

Three more pages carried the same leftover:

- `[app]/settings` — the same broken reference.
- `[project]/settings` and `[env]/settings` — showed `undefined/` beside the read-only slug and, worse, guarded their load with `if (project) return`, inverted when the org half was removed, so neither ever loaded its description.

## What changed

Pages now take their params from Next's generated route types — `PageProps<"/projects/[project]/[env]/[app]">` — which name the segments the directory actually has. A segment spelled wrong is a type error instead of an `undefined` glued into a URL. Every dynamic page is converted, not only the broken ones.

Those types are generated, so `pnpm typecheck` (`next typegen && tsc --noEmit`) writes them first and CI runs that in place of a bare `tsc` — a hand-written params type is never compared against the route, which is why `pnpm run build` did not catch this.

## Verified

- Re-introducing `org` in the destructuring now fails: `Property 'org' does not exist on type '{ project: string; env: string; app: string; }'`.
- Production build served behind a stand-in for the daemon (answers `/api`, proxies the rest) and driven in Chromium: `/projects/web/production/myapp` requests `/api/apps/web/production/myapp`, `/…/deployments` and `/…/env` — no `undefined`, no console errors, page renders. Both settings screens load their data and show the right slug.
- `biome`, `pnpm typecheck`, `pnpm run build` clean. No Go changed; `gofmt` and `go vet` still clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf9kXYsFS5voL84pLFTYiJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf9kXYsFS5voL84pLFTYiJ)_