### PR TITLE
Report the instance's TLS certificates, and the names that have none

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ internal/
   github/       the GitHub App: private clones, and deploy on push
   setup/        the first-run flow that claims an instance
   settings/     the instance's domain and contact address
+  certificates/ what TLS certificates the instance holds, read out of
+                Traefik's own store
   web/          proxies page requests to the dashboard's container
   server/       mounts every module on the HTTP mux and the MCP endpoint
   platform/     infrastructure: database, dockerx, traefik, bootstrap,
@@ -728,6 +730,38 @@ configured, which is why the field is always offered.
 
 A container keeps the labels it was created with, so adding or removing
 a name changes nothing until the app is redeployed.
+
+## Certificates
+
+`internal/certificates` reports what this instance holds and what it is
+missing. It **issues nothing**: Traefik does that, through the ACME
+resolver it is started with, and keeps the result in
+`<data dir>/letsencrypt/acme.json` — the whole store, with no API in
+front of it and no row about it anywhere here.
+
+The daemon can read that file because the data directory is mounted at
+the same path inside and out, which is the same reason everything else
+about that directory works. It decodes each entry's PEM, takes the
+leaf's own facts — names, issuer, validity, serial — and never touches
+the private key sitting beside it.
+
+What the store cannot answer is what the page is for. `reconcile` lines
+the certificates up against every name this instance routes (an app's
+domains, plus the instance's own two) and says which app each one
+serves, which certificate serves nothing any more, and why a name that
+should have one does not: no domain on the instance at all, a name added
+after the app's last deploy — a container keeps the labels it was
+created with — or Traefik knowing the name and not having got one yet.
+That last case quotes the ACME error from `docker logs
+cubeship-traefik`, because it appears nowhere else; a log line that stops
+matching leaves the field empty and the report is still the report.
+
+**It is read-only on purpose.** Renewing or deleting means editing a file
+Traefik owns while it runs, which is only safe with the container
+stopped — a few seconds of downtime for every app — and every re-issue
+spends one of a weekly limit shared with everyone else using the same
+registered domain. That is a decision to make deliberately, not a button
+beside a table.
 
 ## Where an app's image comes from
 

--- a/cmd/cubeshipd/main.go
+++ b/cmd/cubeshipd/main.go
@@ -346,6 +346,7 @@ func run() error {
 		Builder:       builder,
 		LocalRegistry: localRegistry,
 		Frontend:      bootstrap.FrontendAddress(cfg),
+		DataDir:       cfg.DataDir,
 		SetupToken:    setupToken,
 	})
 

--- a/internal/certificates/certificates.go
+++ b/internal/certificates/certificates.go
@@ -1,0 +1,135 @@
+// Package certificates reports the TLS certificates this instance holds,
+// and the names that should have one and do not.
+//
+// Nothing here issues anything. Traefik does that, through the ACME
+// resolver it is started with, and keeps what it gets in acme.json —
+// which is the whole store: there is no API in front of it and no row
+// about it anywhere in Cubeship. This module reads that file, parses the
+// certificates in it, and lines them up against the names this instance
+// actually routes.
+//
+// It is read-only on purpose. Renewing or deleting a certificate would
+// mean editing a file Traefik owns while it runs, which is only safe
+// with the container stopped — a few seconds of downtime for every app —
+// and every re-issue spends one of a weekly limit shared with everyone
+// else using the same registered domain. That is a decision worth making
+// deliberately, not a button beside a table.
+package certificates
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrNoStore reports an instance that has never had a certificate: no
+// domain, so no resolver, so no acme.json. It is not a failure — it is
+// the state a fresh install is in.
+var ErrNoStore = errors.New("this instance has issued no certificates yet")
+
+// Certificate is one certificate in the store, as anybody reading a
+// table wants it. The private key is beside it in the file and is never
+// read: nothing above this could do anything with it but leak it.
+type Certificate struct {
+	// Host is the name the certificate was issued for — Traefik's
+	// "main" domain, which is the router's rule.
+	Host string `json:"host"`
+	// SANs are the other names on it. Cubeship asks for one name per
+	// certificate, so this is normally empty; a certificate issued
+	// before that, or by hand, may carry more.
+	SANs []string `json:"sans,omitempty"`
+	// Issuer is the CA's common name — "R11", "E5", whatever Let's
+	// Encrypt is signing with this season.
+	Issuer    string    `json:"issuer"`
+	NotBefore time.Time `json:"not_before"`
+	NotAfter  time.Time `json:"not_after"`
+	// Serial identifies it to the CA, which is what a support thread
+	// about one asks for.
+	Serial string `json:"serial"`
+
+	// App is the app served at this name, as its reference. Empty for
+	// the instance's own names and for a certificate nothing serves any
+	// more.
+	App string `json:"app,omitempty"`
+	// Instance says the name is the dashboard's or the registry's
+	// rather than an app's.
+	Instance bool `json:"instance,omitempty"`
+	// Orphan says nothing on this instance answers at this name now.
+	// The certificate stays valid and stays in the file; it is simply
+	// paid for and unused.
+	Orphan bool `json:"orphan,omitempty"`
+}
+
+// Expired reports whether the certificate has run out.
+func (c Certificate) Expired(now time.Time) bool { return !now.Before(c.NotAfter) }
+
+// DaysLeft is what a table shows: how long before it stops working.
+// Negative once it has.
+func (c Certificate) DaysLeft(now time.Time) int {
+	return int(c.NotAfter.Sub(now).Hours() / 24)
+}
+
+// Why a name this instance routes has no certificate. The three are
+// three different jobs for whoever reads them: configure the instance,
+// deploy the app, or wait — and then look at the reason Traefik gave.
+type Reason string
+
+const (
+	// ReasonNoTLS is the instance itself: no domain, or no contact
+	// address, so Traefik was started with no resolver at all and asks
+	// for nothing.
+	ReasonNoTLS Reason = "tls_not_configured"
+	// ReasonNotDeployed is a name added to an app that has not been
+	// deployed since. A container keeps the labels it was created with,
+	// so Traefik has never been told this name exists.
+	ReasonNotDeployed Reason = "not_deployed"
+	// ReasonPending is everything else: Traefik knows the name and has
+	// not produced a certificate for it. A minute after a deploy that is
+	// normal; an hour later it is a name that does not resolve here, or
+	// a challenge that failed.
+	ReasonPending Reason = "pending"
+)
+
+// Missing is a name this instance routes with no certificate behind it.
+type Missing struct {
+	Host string `json:"host"`
+	// App is the app served there, empty for the instance's own names.
+	App      string `json:"app,omitempty"`
+	Instance bool   `json:"instance,omitempty"`
+	Reason   Reason `json:"reason"`
+	// Detail is the last thing Traefik said about this name, when it
+	// said anything. It is read out of the container's log rather than
+	// out of any API, so it is a quotation and not a contract: empty is
+	// normal.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Report is the whole picture: what this instance holds, what it is
+// missing, and whether it could have any of it.
+type Report struct {
+	// TLSEnabled is whether certificates are possible at all. False and
+	// everything below is empty, which is the answer rather than a
+	// failure.
+	TLSEnabled bool `json:"tls_enabled"`
+	// ACMEEmail is the contact Let's Encrypt has for this instance, as
+	// the store recorded it — which is the one that counts, not the one
+	// in the settings, if somebody changed it after registering.
+	ACMEEmail    string        `json:"acme_email,omitempty"`
+	Certificates []Certificate `json:"certificates"`
+	Missing      []Missing     `json:"missing"`
+}
+
+// ServedHost is a name this instance routes and what answers there. It
+// is what the report is checked against: a certificate for a name
+// nothing serves is an orphan, and a served name with no certificate is
+// missing one.
+type ServedHost struct {
+	Host string
+	// App is the app's reference, empty for the instance's own names.
+	App string
+	// Instance says this is the dashboard's or the registry's name.
+	Instance bool
+	// Deployed says a container is actually running with this name in
+	// its labels. A name added and not yet deployed is one Traefik has
+	// never heard of.
+	Deployed bool
+}

--- a/internal/certificates/certificates_test.go
+++ b/internal/certificates/certificates_test.go
@@ -1,0 +1,248 @@
+package certificates_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cubeship/internal/certificates"
+	"cubeship/internal/server/servertest"
+	"cubeship/internal/user"
+)
+
+func report(t *testing.T, f *servertest.Fixture, key string) certificates.Report {
+	t.Helper()
+	rec := f.Do(t, http.MethodGet, "/certificates", nil, key)
+	servertest.RequireStatus(t, rec, http.StatusOK)
+
+	var got certificates.Report
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode the report: %v", err)
+	}
+	return got
+}
+
+// How the instance is wired is the operator's business. A member sees an
+// app's domains on the app; whether a certificate was issued for one is
+// not part of that.
+func TestOnlyAnAdminReadsTheCertificates(t *testing.T) {
+	f := servertest.New(t)
+	_, memberKey := f.AddMember(t, "member", user.RoleMember)
+
+	servertest.RequireStatus(t, f.Do(t, http.MethodGet, "/certificates", nil, memberKey),
+		http.StatusForbidden)
+	servertest.RequireStatus(t, f.Do(t, http.MethodGet, "/certificates", nil, f.AdminKey),
+		http.StatusOK)
+}
+
+// An instance with no store has issued nothing, and says so with an
+// empty report rather than an error — that is the state a fresh install
+// is in, and it is on the page for a reason.
+func TestAnInstanceThatHasIssuedNothing(t *testing.T) {
+	f := servertest.New(t)
+
+	got := report(t, f, f.AdminKey)
+	if len(got.Certificates) != 0 {
+		t.Errorf("certificates: %+v", got.Certificates)
+	}
+	if !got.TLSEnabled {
+		t.Error("TLS is reported as impossible on an instance with a domain")
+	}
+	// The names are known and nothing has been issued for them yet,
+	// which is what pending means.
+	if len(got.Missing) == 0 {
+		t.Fatal("nothing is reported as missing a certificate")
+	}
+	for _, m := range got.Missing {
+		if m.Reason != certificates.ReasonPending {
+			t.Errorf("%s is %q, want %q", m.Host, m.Reason, certificates.ReasonPending)
+		}
+	}
+}
+
+// Without a domain Traefik is started with no resolver at all: it asks
+// for nothing, so no name is waiting on anything. The instance is the
+// answer, not the name.
+func TestWithNoDomainNothingIsPending(t *testing.T) {
+	f := servertest.NewUnconfigured(t)
+
+	var created struct {
+		Reference string `json:"reference"`
+	}
+	servertest.RequireStatus(t, f.DoJSON(t, http.MethodPost, "/apps", map[string]string{
+		"name": "gateway", "project": "web",
+	}, f.AdminKey, &created), http.StatusCreated)
+	servertest.AddDomain(t, f, f.AdminKey, created.Reference, "gateway.example.com")
+
+	got := report(t, f, f.AdminKey)
+	if got.TLSEnabled {
+		t.Error("TLS is reported as possible with no domain")
+	}
+	if len(got.Missing) != 1 || got.Missing[0].Reason != certificates.ReasonNoTLS {
+		t.Errorf("missing is %+v", got.Missing)
+	}
+}
+
+// The instance's own two names are on the page. They are the ones an
+// operator notices first when HTTPS stops working, and neither belongs
+// to an app.
+func TestTheInstancesOwnNamesAreReported(t *testing.T) {
+	f := servertest.New(t)
+
+	want := map[string]bool{
+		servertest.APIHost:      false,
+		servertest.RegistryHost: false,
+	}
+	for _, m := range report(t, f, f.AdminKey).Missing {
+		if _, ok := want[m.Host]; ok {
+			if !m.Instance {
+				t.Errorf("%s is not marked as the instance's own", m.Host)
+			}
+			want[m.Host] = true
+		}
+	}
+	for host, found := range want {
+		if !found {
+			t.Errorf("%s is not in the report", host)
+		}
+	}
+}
+
+// A name added to an app that has not been deployed since is a name
+// Traefik has never been told about: a container keeps the labels it was
+// created with. That is the commonest reason a certificate is missing,
+// and the answer to it is "redeploy" rather than anything about DNS.
+func TestANameAddedAndNotDeployedSaysSo(t *testing.T) {
+	f := servertest.New(t)
+
+	var created struct {
+		Reference string `json:"reference"`
+	}
+	servertest.RequireStatus(t, f.DoJSON(t, http.MethodPost, "/apps", map[string]string{
+		"name": "gateway", "project": "web",
+	}, f.AdminKey, &created), http.StatusCreated)
+	servertest.AddDomain(t, f, f.AdminKey, created.Reference, "gateway.example.com")
+
+	var found *certificates.Missing
+	for _, m := range report(t, f, f.AdminKey).Missing {
+		if m.Host == "gateway.example.com" {
+			found = &m
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("the app's name is not reported as missing a certificate")
+	}
+	if found.App != created.Reference {
+		t.Errorf("it is attributed to %q, want %q", found.App, created.Reference)
+	}
+	if found.Reason != certificates.ReasonNotDeployed {
+		t.Errorf("the reason is %q, want %q", found.Reason, certificates.ReasonNotDeployed)
+	}
+}
+
+// storeWith writes an acme.json holding one certificate for each name,
+// the way Traefik does. It generates them here rather than carrying a
+// fixture: a certificate in a repository is one that expires.
+func storeWith(t *testing.T, dataDir string, hosts ...string) {
+	t.Helper()
+
+	entries := make([]map[string]any, 0, len(hosts))
+	for _, host := range hosts {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatal(err)
+		}
+		template := x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject:      pkix.Name{CommonName: host},
+			DNSNames:     []string{host},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(60 * 24 * time.Hour),
+		}
+		der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries = append(entries, map[string]any{
+			"domain": map[string]any{"main": host},
+			"certificate": base64.StdEncoding.EncodeToString(
+				pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})),
+		})
+	}
+
+	path := certificates.StorePath(dataDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(map[string]any{
+		"letsencrypt": map[string]any{
+			"Account":      map[string]any{"Email": "ops@example.com"},
+			"Certificates": entries,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The whole path, from the file Traefik writes to what a page renders:
+// a certificate is found, attributed to the app served at that name, and
+// one for a name nothing serves any more is called what it is.
+func TestTheReportReadsTheStoreAndAttributesEachCertificate(t *testing.T) {
+	f := servertest.New(t)
+
+	var created struct {
+		Reference string `json:"reference"`
+	}
+	servertest.RequireStatus(t, f.DoJSON(t, http.MethodPost, "/apps", map[string]string{
+		"name": "gateway", "project": "web",
+	}, f.AdminKey, &created), http.StatusCreated)
+	servertest.AddDomain(t, f, f.AdminKey, created.Reference, "gateway.example.com")
+
+	storeWith(t, f.DataDir, "gateway.example.com", "deleted.example.com", servertest.APIHost)
+
+	got := report(t, f, f.AdminKey)
+	if got.ACMEEmail != "ops@example.com" {
+		t.Errorf("the account email is %q", got.ACMEEmail)
+	}
+	if len(got.Certificates) != 3 {
+		t.Fatalf("read %d certificates, want 3", len(got.Certificates))
+	}
+
+	byHost := map[string]certificates.Certificate{}
+	for _, c := range got.Certificates {
+		byHost[c.Host] = c
+	}
+	if got := byHost["gateway.example.com"]; got.App != created.Reference || got.Orphan {
+		t.Errorf("the app's certificate came out %+v", got)
+	}
+	if got := byHost[servertest.APIHost]; !got.Instance || got.Orphan {
+		t.Errorf("the instance's certificate came out %+v", got)
+	}
+	// An app deleted after its certificate was issued leaves it behind:
+	// still valid, still in the file, serving nothing.
+	if got := byHost["deleted.example.com"]; !got.Orphan {
+		t.Errorf("a certificate nothing serves came out %+v", got)
+	}
+
+	// And the name that now has one is no longer reported as missing.
+	for _, m := range got.Missing {
+		if m.Host == "gateway.example.com" {
+			t.Errorf("a name with a certificate is still reported missing one: %+v", m)
+		}
+	}
+}

--- a/internal/certificates/http.go
+++ b/internal/certificates/http.go
@@ -1,0 +1,40 @@
+package certificates
+
+import (
+	"errors"
+	"net/http"
+
+	"cubeship/internal/platform/httpx"
+	"cubeship/internal/user"
+)
+
+type Handler struct {
+	svc *Service
+}
+
+func NewHandler(svc *Service) *Handler { return &Handler{svc: svc} }
+
+func (h *Handler) Routes(r *httpx.Router, auth func(http.Handler) http.Handler) {
+	r.Handle("GET /certificates", auth(http.HandlerFunc(h.report)))
+}
+
+func WriteError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, user.ErrForbidden):
+		http.Error(w, err.Error(), http.StatusForbidden)
+	case errors.Is(err, user.ErrUnauthenticated):
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	default:
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *Handler) report(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	report, err := h.svc.Report(ctx, user.FromContext(ctx))
+	if err != nil {
+		WriteError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, report)
+}

--- a/internal/certificates/openapi.go
+++ b/internal/certificates/openapi.go
@@ -1,0 +1,58 @@
+package certificates
+
+import "cubeship/internal/platform/openapi"
+
+func (h *Handler) OpenAPI() openapi.Spec {
+	return openapi.Spec{
+		Tags: []openapi.Tag{{
+			Name: "Certificates",
+			Description: "What TLS certificates this instance holds, and which of the names it serves have none.\n\n" +
+				"Traefik issues them through Let's Encrypt and keeps them in its own store; this reads that store. " +
+				"Nothing here issues, renews or deletes anything — renewal is automatic, thirty days before expiry.",
+		}},
+		Schemas: map[string]*openapi.Schema{
+			"Certificate": openapi.Object(map[string]*openapi.Schema{
+				"host":       openapi.String("The name it was issued for."),
+				"sans":       openapi.Array(openapi.String("Any other name on the same certificate.")),
+				"issuer":     openapi.String("The CA that signed it."),
+				"not_before": openapi.String("RFC 3339."),
+				"not_after":  openapi.String("RFC 3339. Traefik renews thirty days before this."),
+				"serial":     openapi.String("The CA's serial, hex, colon separated."),
+				"app":        openapi.String("The app served at that name, as its reference. Absent for the instance's own names."),
+				"instance":   openapi.Bool("The name is the dashboard's or the registry's rather than an app's."),
+				"orphan":     openapi.Bool("Nothing on this instance answers at that name any more. The certificate is still valid; it is simply unused."),
+			}, "host", "issuer", "not_before", "not_after", "serial"),
+			"MissingCertificate": openapi.Object(map[string]*openapi.Schema{
+				"host":     openapi.String("A name this instance routes with no certificate behind it."),
+				"app":      openapi.String("The app served there, as its reference. Absent for the instance's own names."),
+				"instance": openapi.Bool("The name is the dashboard's or the registry's."),
+				"reason": openapi.String("`tls_not_configured` — the instance has no domain or no contact address, so Traefik asks for nothing. " +
+					"`not_deployed` — the name was added after the app's last deploy, and a container keeps the labels it was created with, so Traefik has never been told about it. " +
+					"`pending` — Traefik knows the name and has not produced a certificate: normal for a minute after a deploy, and after that a name that does not resolve here or a challenge that failed."),
+				"detail": openapi.String("The last thing Traefik's log said about that name, when it said anything. A quotation, not a contract."),
+			}, "host", "reason"),
+			"CertificateReport": openapi.Object(map[string]*openapi.Schema{
+				"tls_enabled":  openapi.Bool("Whether certificates are possible at all, which needs both a domain and a contact address."),
+				"acme_email":   openapi.String("The contact Let's Encrypt has, as the store recorded it — which is the one that counts if the setting was changed after registering."),
+				"certificates": openapi.Array(openapi.Ref("Certificate")),
+				"missing":      openapi.Array(openapi.Ref("MissingCertificate")),
+			}, "tls_enabled", "certificates", "missing"),
+		},
+		Paths: map[string]openapi.PathItem{
+			"/certificates": {
+				"get": {
+					OperationID: "getCertificates",
+					Summary:     "List this instance's TLS certificates",
+					Description: "Every certificate Traefik holds, with what it is for and when it runs out, plus every name this instance routes that has none and why.\n\n" +
+						"Admin only: this is how the instance is wired, not an app's own configuration. Private keys are in the same store and are never read.",
+					Tags: []string{"Certificates"},
+					Responses: openapi.Responses{
+						"200": openapi.JSONResponse("The report.", openapi.Ref("CertificateReport")),
+						"401": openapi.Unauthorized,
+						"403": openapi.Forbidden,
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/certificates/reconcile_test.go
+++ b/internal/certificates/reconcile_test.go
@@ -1,0 +1,91 @@
+package certificates
+
+import "testing"
+
+func servedApp(host, reference string, deployed bool) ServedHost {
+	return ServedHost{Host: host, App: reference, Deployed: deployed}
+}
+
+// The comparison is the point of the page: a certificate is for a name,
+// a name belongs to an app, and either side can exist without the other.
+func TestWhatEachSideOfTheComparisonMeans(t *testing.T) {
+	certs := []Certificate{
+		{Host: "kept.example.com"},
+		{Host: "gone.example.com"},
+		{Host: "cubeship.example.com"},
+	}
+	served := []ServedHost{
+		servedApp("kept.example.com", "web/production/kept", true),
+		servedApp("waiting.example.com", "web/production/waiting", true),
+		servedApp("added.example.com", "web/production/added", false),
+		{Host: "cubeship.example.com", Instance: true, Deployed: true},
+	}
+
+	out, missing := reconcile(certs, served, true)
+
+	byHost := map[string]Certificate{}
+	for _, c := range out {
+		byHost[c.Host] = c
+	}
+	if got := byHost["kept.example.com"]; got.App != "web/production/kept" || got.Orphan {
+		t.Errorf("a certificate for a served name came out %+v", got)
+	}
+	if got := byHost["cubeship.example.com"]; !got.Instance || got.Orphan {
+		t.Errorf("the instance's own certificate came out %+v", got)
+	}
+	// Nothing answers there any more. It stays valid and stays in the
+	// file; the only thing wrong with it is that it was paid for.
+	if got := byHost["gone.example.com"]; !got.Orphan || got.App != "" {
+		t.Errorf("a certificate for a name nothing serves came out %+v", got)
+	}
+
+	reasons := map[string]Reason{}
+	for _, m := range missing {
+		reasons[m.Host] = m.Reason
+	}
+	if len(missing) != 2 {
+		t.Fatalf("missing is %+v, want two entries", missing)
+	}
+	// A name Traefik knows about and has not got a certificate for.
+	if reasons["waiting.example.com"] != ReasonPending {
+		t.Errorf("waiting.example.com is %q", reasons["waiting.example.com"])
+	}
+	// A name added after the last deploy is one Traefik has never been
+	// told about — a container keeps the labels it was created with.
+	if reasons["added.example.com"] != ReasonNotDeployed {
+		t.Errorf("added.example.com is %q", reasons["added.example.com"])
+	}
+}
+
+// With no domain or no contact address Traefik is started with no
+// resolver at all, so nothing is pending: the instance is the answer,
+// not the name.
+func TestWithoutTLSEveryNameHasTheSameReason(t *testing.T) {
+	_, missing := reconcile(nil, []ServedHost{
+		servedApp("a.example.com", "web/production/a", true),
+		servedApp("b.example.com", "web/production/b", false),
+	}, false)
+
+	if len(missing) != 2 {
+		t.Fatalf("missing is %+v", missing)
+	}
+	for _, m := range missing {
+		if m.Reason != ReasonNoTLS {
+			t.Errorf("%s is %q, want %q", m.Host, m.Reason, ReasonNoTLS)
+		}
+	}
+}
+
+// A certificate covering several names covers all of them: a name on a
+// SAN is not missing a certificate.
+func TestANameOnASANIsNotMissing(t *testing.T) {
+	certs := []Certificate{{Host: "api.example.com", SANs: []string{"admin.example.com"}}}
+	_, missing := reconcile(certs, []ServedHost{
+		servedApp("api.example.com", "web/production/api", true),
+		servedApp("admin.example.com", "web/production/api", true),
+	}, true)
+
+	if len(missing) != 0 {
+		t.Errorf("missing is %+v, want none", missing)
+	}
+}

--- a/internal/certificates/service.go
+++ b/internal/certificates/service.go
@@ -1,0 +1,278 @@
+package certificates
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"sort"
+	"strings"
+
+	"cubeship/internal/app"
+	"cubeship/internal/platform/dockerx"
+	"cubeship/internal/settings"
+	"cubeship/internal/user"
+)
+
+// TraefikContainer is the container whose log says why a certificate was
+// not issued. It must match bootstrap.TraefikContainerOpts.
+const TraefikContainer = "cubeship-traefik"
+
+// logTail is how much of Traefik's log is read looking for a reason. Far
+// enough back to cover the last few deploys, short enough that reading
+// it is not a job.
+const logTail = "2000"
+
+// Engine is the little of Docker this module needs: the ACME failures
+// are in Traefik's log and nowhere else.
+//
+// It is optional. Without it the report is the same minus the quotations
+// — which is what a test gets, and what an instance whose Docker client
+// cannot inspect containers gets.
+type Engine interface {
+	InspectContainerByName(ctx context.Context, name string) (dockerx.ContainerInfo, error)
+	Logs(ctx context.Context, id, tail string) (io.ReadCloser, error)
+}
+
+// Service reads the certificate store and lines it up against what this
+// instance routes.
+//
+// It sits above app for the same reason registry does: the names that
+// should have certificates are the apps' names, and only app knows them.
+type Service struct {
+	settings *settings.Service
+	apps     *app.Service
+	dataDir  string
+
+	engine Engine
+}
+
+func NewService(cfg *settings.Service, apps *app.Service, dataDir string) *Service {
+	return &Service{settings: cfg, apps: apps, dataDir: dataDir}
+}
+
+// SetEngine wires the Docker client the log quotations come from. The
+// server does it when its client can inspect containers.
+func (s *Service) SetEngine(e Engine) { s.engine = e }
+
+// Report is the whole answer: every certificate this instance holds, and
+// every name it routes that has none.
+//
+// An admin's, like everything else about how the instance is wired. A
+// member sees an app's domains on the app; whether the instance managed
+// to get a certificate for one is the operator's business.
+func (s *Service) Report(ctx context.Context, caller *user.User) (Report, error) {
+	if err := user.Require(caller, user.RoleAdmin); err != nil {
+		return Report{}, err
+	}
+
+	values, err := s.settings.Load(ctx)
+	if err != nil {
+		return Report{}, err
+	}
+	report := Report{
+		TLSEnabled:   values.HasTLS(),
+		Certificates: []Certificate{},
+		Missing:      []Missing{},
+	}
+
+	served, err := s.servedHosts(ctx, values)
+	if err != nil {
+		return Report{}, err
+	}
+
+	email, certs, err := readStore(StorePath(s.dataDir))
+	if err != nil && !errors.Is(err, ErrNoStore) {
+		return Report{}, err
+	}
+	report.ACMEEmail = email
+
+	report.Certificates, report.Missing = reconcile(certs, served, report.TLSEnabled)
+	s.explain(ctx, report.Missing)
+	return report, nil
+}
+
+// reconcile is the whole of the comparison, kept apart from where the
+// two sides come from so it can be read — and tested — on its own.
+//
+// A certificate whose name nothing serves is an orphan: it stays valid
+// and stays in the file, and the only thing wrong with it is that it was
+// paid for. A served name with no certificate is missing one, and why
+// depends on how far the name got.
+func reconcile(certs []Certificate, served []ServedHost, tls bool) ([]Certificate, []Missing) {
+	byHost := make(map[string]ServedHost, len(served))
+	for _, h := range served {
+		byHost[app.NormalizeHost(h.Host)] = h
+	}
+
+	out := make([]Certificate, 0, len(certs))
+	covered := make(map[string]bool, len(certs))
+	for _, c := range certs {
+		covered[c.Host] = true
+		for _, san := range c.SANs {
+			covered[san] = true
+		}
+		if h, ok := byHost[c.Host]; ok {
+			c.App, c.Instance = h.App, h.Instance
+		} else {
+			c.Orphan = true
+		}
+		out = append(out, c)
+	}
+
+	missing := make([]Missing, 0)
+	for _, h := range served {
+		host := app.NormalizeHost(h.Host)
+		if covered[host] {
+			continue
+		}
+		missing = append(missing, Missing{
+			Host: host, App: h.App, Instance: h.Instance,
+			Reason: reasonFor(h, tls),
+		})
+	}
+	sort.Slice(missing, func(i, j int) bool { return missing[i].Host < missing[j].Host })
+	return out, missing
+}
+
+func reasonFor(h ServedHost, tls bool) Reason {
+	switch {
+	case !tls:
+		return ReasonNoTLS
+	case !h.Deployed:
+		return ReasonNotDeployed
+	default:
+		return ReasonPending
+	}
+}
+
+// servedHosts is every name this instance routes: its own two, and every
+// name on every app.
+//
+// "Deployed" is the difference between a name Traefik knows about and
+// one that only exists here. A container keeps the labels it was created
+// with, so a name added after the last deploy is a name Traefik has
+// never been told about — which is the commonest reason a certificate is
+// missing, and the one whose answer is "redeploy".
+func (s *Service) servedHosts(ctx context.Context, values settings.Values) ([]ServedHost, error) {
+	var out []ServedHost
+
+	if domain := values.Get(settings.Domain); domain != "" {
+		// Both are routed by Traefik with the same resolver: the
+		// dashboard and API at the domain itself, the registry beside
+		// it. Neither belongs to an app.
+		out = append(out,
+			ServedHost{Host: settings.APIHostFor(domain), Instance: true, Deployed: true},
+			ServedHost{Host: settings.RegistryHostFor(domain), Instance: true, Deployed: true})
+	}
+
+	apps, err := s.apps.Repo().ListScoped(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int64, 0, len(apps))
+	for _, a := range apps {
+		ids = append(ids, a.ID)
+	}
+	domains, err := s.apps.Repo().DomainsFor(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range apps {
+		reference := app.ReferenceOf(a).String()
+		for _, d := range domains[a.ID] {
+			out = append(out, ServedHost{
+				Host: d.Host,
+				App:  reference,
+				// The container carries the labels, so a name is only
+				// really routed once something is running with it.
+				Deployed: a.ContainerID != "",
+			})
+		}
+	}
+	return out, nil
+}
+
+// explain fills in what Traefik said about each name it could not get a
+// certificate for.
+//
+// It reads the container's log, because Traefik has no API for this and
+// the ACME error appears nowhere else. That makes it a quotation rather
+// than a contract: a log line that stops matching leaves the field
+// empty, and the report is still the report.
+func (s *Service) explain(ctx context.Context, missing []Missing) {
+	if s.engine == nil || len(missing) == 0 {
+		return
+	}
+	pending := false
+	for _, m := range missing {
+		if m.Reason == ReasonPending {
+			pending = true
+			break
+		}
+	}
+	if !pending {
+		return
+	}
+
+	info, err := s.engine.InspectContainerByName(ctx, TraefikContainer)
+	if err != nil || info.ID == "" {
+		return
+	}
+	logs, err := s.engine.Logs(ctx, info.ID, logTail)
+	if err != nil {
+		return
+	}
+	defer logs.Close()
+
+	lines := errorLines(logs)
+	for i := range missing {
+		if missing[i].Reason != ReasonPending {
+			continue
+		}
+		if line, ok := lines[app.NormalizeHost(missing[i].Host)]; ok {
+			missing[i].Detail = line
+		}
+	}
+}
+
+// errorLines keeps the last thing Traefik complained about, per host.
+//
+// Docker frames the log, and a frame header is a few bytes of binary in
+// front of each line. Nothing here needs to be exact about it: the
+// scanner reads lines, the header lands at the start of one, and the
+// host is looked for anywhere in it.
+func errorLines(r io.Reader) map[string]string {
+	out := map[string]string{}
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		line := strings.TrimSpace(strings.Map(printable, scanner.Text()))
+		lower := strings.ToLower(line)
+		if !strings.Contains(lower, "error") && !strings.Contains(lower, "unable") {
+			continue
+		}
+		if !strings.Contains(lower, "acme") && !strings.Contains(lower, "certificate") {
+			continue
+		}
+		// The host appears in the message; which one it is decides
+		// whose line this is.
+		for _, field := range strings.FieldsFunc(lower, func(r rune) bool {
+			return r == '"' || r == ' ' || r == '\'' || r == ',' || r == ':'
+		}) {
+			if strings.Contains(field, ".") {
+				out[app.NormalizeHost(field)] = line
+			}
+		}
+	}
+	return out
+}
+
+// printable drops the frame header's control bytes, which would
+// otherwise land in a JSON string somebody reads.
+func printable(r rune) rune {
+	if r < 32 || r == 127 {
+		return -1
+	}
+	return r
+}

--- a/internal/certificates/store.go
+++ b/internal/certificates/store.go
@@ -1,0 +1,165 @@
+package certificates
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"cubeship/internal/app"
+)
+
+// StorePath is where Traefik keeps what it was issued, inside the data
+// directory. It is the host side of the bind mount Traefik is given as
+// /letsencrypt, and the daemon has the data directory mounted at the
+// same path — which is what lets this be read at all.
+//
+// It must match bootstrap.TraefikContainerOpts.
+func StorePath(dataDir string) string {
+	return filepath.Join(dataDir, "letsencrypt", "acme.json")
+}
+
+// acmeStore is acme.json: one entry per resolver, each holding the ACME
+// account and everything issued through it. Cubeship configures one
+// resolver, "letsencrypt", but the file's shape is a map and reading it
+// as one costs nothing.
+type acmeStore map[string]struct {
+	Account struct {
+		Email string `json:"Email"`
+	} `json:"Account"`
+	Certificates []storedCertificate `json:"Certificates"`
+}
+
+// storedCertificate is one entry. The certificate and key are
+// base64-encoded PEM; the key is never decoded here — nothing above
+// this could do anything with it that is not a leak.
+type storedCertificate struct {
+	Domain struct {
+		Main string   `json:"main"`
+		SANs []string `json:"sans"`
+	} `json:"domain"`
+	Certificate string `json:"certificate"`
+}
+
+// readStore parses the ACME store and returns what it holds, newest
+// expiry last.
+//
+// A store that is not there is ErrNoStore rather than an error: an
+// instance with no domain has no resolver, so Traefik never writes the
+// file, and that is a state to report rather than a failure to explain.
+func readStore(path string) (email string, certs []Certificate, err error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil, ErrNoStore
+	}
+	if err != nil {
+		return "", nil, fmt.Errorf("read the ACME store at %s: %w", path, err)
+	}
+	// Traefik creates the file before it has anything to put in it.
+	if len(raw) == 0 {
+		return "", nil, ErrNoStore
+	}
+
+	var store acmeStore
+	if err := json.Unmarshal(raw, &store); err != nil {
+		return "", nil, fmt.Errorf("parse the ACME store at %s: %w", path, err)
+	}
+
+	for _, resolver := range store {
+		if email == "" {
+			email = resolver.Account.Email
+		}
+		for _, stored := range resolver.Certificates {
+			c, err := parseStored(stored)
+			if err != nil {
+				// One unreadable entry must not hide the rest: the
+				// point of this page is the ones that are about to
+				// expire.
+				continue
+			}
+			certs = append(certs, c)
+		}
+	}
+	sort.Slice(certs, func(i, j int) bool {
+		if certs[i].NotAfter.Equal(certs[j].NotAfter) {
+			return certs[i].Host < certs[j].Host
+		}
+		return certs[i].NotAfter.Before(certs[j].NotAfter)
+	})
+	return email, certs, nil
+}
+
+// parseStored turns one entry into what a reader wants: the leaf
+// certificate's own facts. The chain below it is the CA's, and says
+// nothing about this name.
+func parseStored(stored storedCertificate) (Certificate, error) {
+	der, err := base64.StdEncoding.DecodeString(stored.Certificate)
+	if err != nil {
+		return Certificate{}, fmt.Errorf("decode the certificate for %q: %w", stored.Domain.Main, err)
+	}
+	block, _ := pem.Decode(der)
+	if block == nil {
+		return Certificate{}, fmt.Errorf("no PEM block in the certificate for %q", stored.Domain.Main)
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return Certificate{}, fmt.Errorf("parse the certificate for %q: %w", stored.Domain.Main, err)
+	}
+
+	host := stored.Domain.Main
+	if host == "" && len(leaf.DNSNames) > 0 {
+		host = leaf.DNSNames[0]
+	}
+	return Certificate{
+		Host:      app.NormalizeHost(host),
+		SANs:      otherNames(host, leaf.DNSNames),
+		Issuer:    leaf.Issuer.CommonName,
+		NotBefore: leaf.NotBefore.UTC(),
+		NotAfter:  leaf.NotAfter.UTC(),
+		Serial:    serialOf(leaf.SerialNumber),
+	}, nil
+}
+
+// otherNames is every name on the certificate except the one it is
+// filed under, which is already the row's title.
+func otherNames(main string, names []string) []string {
+	var out []string
+	for _, name := range names {
+		if !equalHost(name, main) {
+			out = append(out, app.NormalizeHost(name))
+		}
+	}
+	return out
+}
+
+// serialOf renders a serial the way a CA writes it: hex, colon
+// separated, which is what a support thread about one asks for.
+func serialOf(serial *big.Int) string {
+	if serial == nil {
+		return ""
+	}
+	raw := serial.Bytes()
+	if len(raw) == 0 {
+		return "00"
+	}
+	out := make([]byte, 0, len(raw)*3-1)
+	const hex = "0123456789abcdef"
+	for i, b := range raw {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hex[b>>4], hex[b&0x0f])
+	}
+	return string(out)
+}
+
+// equalHost compares two names the way a browser and Traefik do.
+func equalHost(a, b string) bool {
+	return app.NormalizeHost(a) == app.NormalizeHost(b)
+}

--- a/internal/certificates/store_test.go
+++ b/internal/certificates/store_test.go
@@ -1,0 +1,184 @@
+package certificates
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// issue makes a certificate the way Let's Encrypt would hand one over,
+// so the parser is exercised on the real shape rather than on a fixture
+// somebody typed.
+func issue(t *testing.T, host string, notAfter time.Time, sans ...string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Signed by something else, the way a real one is: the issuer is the
+	// CA's name, and this page shows it.
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ca := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "R11"},
+		NotBefore:             notAfter.Add(-365 * 24 * time.Hour),
+		NotAfter:              notAfter.Add(365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(0x0a0b0c),
+		Subject:      pkix.Name{CommonName: host},
+		DNSNames:     append([]string{host}, sans...),
+		NotBefore:    notAfter.Add(-90 * 24 * time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Traefik stores base64 of the PEM chain, not of the DER.
+	return base64.StdEncoding.EncodeToString(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+// writeStore lays out an acme.json the way Traefik does: one entry per
+// resolver, the account beside the certificates.
+func writeStore(t *testing.T, dataDir string, email string, entries ...map[string]any) string {
+	t.Helper()
+	path := StorePath(dataDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store := map[string]any{
+		"letsencrypt": map[string]any{
+			"Account":      map[string]any{"Email": email},
+			"Certificates": entries,
+		},
+	}
+	raw, err := json.Marshal(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func entry(host, certificate string) map[string]any {
+	return map[string]any{
+		"domain":      map[string]any{"main": host},
+		"certificate": certificate,
+		// The key is in the file beside it. Nothing reads it, and this
+		// is here so that stays true by being noticed if it changes.
+		"key":   "c2VjcmV0",
+		"Store": "default",
+	}
+}
+
+// The store is Traefik's, and this reads it: what it holds, when each
+// one runs out, and who signed it.
+func TestReadingTraefiksStore(t *testing.T) {
+	dir := t.TempDir()
+	expires := time.Now().Add(45 * 24 * time.Hour).UTC().Truncate(time.Second)
+	path := writeStore(t, dir, "ops@example.com",
+		entry("late.example.com", issue(t, "late.example.com", expires)),
+		entry("soon.example.com", issue(t, "soon.example.com", expires.Add(-30*24*time.Hour))))
+
+	email, certs, err := readStore(path)
+	if err != nil {
+		t.Fatalf("readStore: %v", err)
+	}
+	if email != "ops@example.com" {
+		t.Errorf("account email is %q", email)
+	}
+	if len(certs) != 2 {
+		t.Fatalf("read %d certificates, want 2", len(certs))
+	}
+	// Soonest first: the table is read for what is about to break.
+	if certs[0].Host != "soon.example.com" || certs[1].Host != "late.example.com" {
+		t.Errorf("order is %q then %q", certs[0].Host, certs[1].Host)
+	}
+	if !certs[1].NotAfter.Equal(expires) {
+		t.Errorf("expiry is %s, want %s", certs[1].NotAfter, expires)
+	}
+	if certs[1].Issuer != "R11" {
+		t.Errorf("issuer is %q", certs[1].Issuer)
+	}
+	if certs[1].Serial != "0a:0b:0c" {
+		t.Errorf("serial is %q", certs[1].Serial)
+	}
+	if days := certs[1].DaysLeft(time.Now()); days < 43 || days > 45 {
+		t.Errorf("days left is %d, want about 45", days)
+	}
+}
+
+// The names beside the main one are worth showing, and the main one is
+// not repeated among them — it is already the row's title.
+func TestTheOtherNamesOnACertificate(t *testing.T) {
+	dir := t.TempDir()
+	path := writeStore(t, dir, "",
+		entry("api.example.com", issue(t, "api.example.com", time.Now().Add(time.Hour), "admin.example.com")))
+
+	_, certs, err := readStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(certs) != 1 || len(certs[0].SANs) != 1 || certs[0].SANs[0] != "admin.example.com" {
+		t.Fatalf("read %+v", certs)
+	}
+}
+
+// An instance with no domain has no resolver, so Traefik never writes
+// the file. That is a state to report, not a failure to explain — and
+// the same goes for the empty file it creates before it has anything to
+// put in it.
+func TestNoStoreIsAState(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := readStore(StorePath(dir)); !errors.Is(err, ErrNoStore) {
+		t.Errorf("a missing store answered %v", err)
+	}
+
+	path := StorePath(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := readStore(path); !errors.Is(err, ErrNoStore) {
+		t.Errorf("an empty store answered %v", err)
+	}
+}
+
+// One unreadable entry must not hide the rest. The reason to open this
+// page is the certificate that is about to expire, and it should still
+// be on it.
+func TestAnUnreadableEntryDoesNotHideTheOthers(t *testing.T) {
+	dir := t.TempDir()
+	path := writeStore(t, dir, "",
+		entry("broken.example.com", "not base64 at all"),
+		entry("fine.example.com", issue(t, "fine.example.com", time.Now().Add(time.Hour))))
+
+	_, certs, err := readStore(path)
+	if err != nil {
+		t.Fatalf("readStore: %v", err)
+	}
+	if len(certs) != 1 || certs[0].Host != "fine.example.com" {
+		t.Fatalf("read %+v", certs)
+	}
+}

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"cubeship/internal/app"
+	"cubeship/internal/certificates"
 	"cubeship/internal/dns"
 	"cubeship/internal/extregistry"
 	"cubeship/internal/github"
@@ -43,7 +44,8 @@ func (s *Server) OpenAPI() openapi.Document {
 		dns.NewHandler(s.DNS).OpenAPI(),
 		github.NewHandler(s.GitHub, s.Apps).OpenAPI(),
 		s.Registry.OpenAPI(),
-		settings.NewHandler(s.Settings).OpenAPI())
+		settings.NewHandler(s.Settings).OpenAPI(),
+		certificates.NewHandler(s.Certs).OpenAPI())
 
 	return openapi.Document{
 		OpenAPI: "3.1.0",

--- a/internal/server/openapi_test.go
+++ b/internal/server/openapi_test.go
@@ -92,6 +92,7 @@ func TestDocumentedSurfaceIsTheProductAPI(t *testing.T) {
 		"GET /apps/{project}/{env}/{name}/deployments/{id}",
 		"GET /apps/{project}/{env}/{name}/env",
 		"GET /apps/{project}/{env}/{name}/logs",
+		"GET /certificates",
 		"GET /dns",
 		"GET /dns/{id}/records",
 		"GET /dns/{id}/status",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 
 	"cubeship/internal/app"
+	"cubeship/internal/certificates"
 	"cubeship/internal/dns"
 	"cubeship/internal/extregistry"
 	"cubeship/internal/github"
@@ -30,6 +31,7 @@ type Server struct {
 	Projects   *project.Service
 	Apps       *app.Service
 	Settings   *settings.Service
+	Certs      *certificates.Service
 	Setup      *setup.Service
 	Registries *extregistry.Service
 	DNS        *dns.Service
@@ -75,6 +77,11 @@ type Options struct {
 	// of `make web-dev`.
 	Frontend string
 
+	// DataDir is where the instance keeps its state, and the one thing
+	// outside the database a module reads: Traefik's certificate store
+	// lives in it.
+	DataDir string
+
 	// SetupToken guards claiming an unclaimed instance. The daemon
 	// writes it into the data directory on first start and the
 	// installer prints it; a zero value asks for none, which is what a
@@ -105,6 +112,7 @@ func New(db *database.DB, docker app.DockerAPI, opts Options) *Server {
 		Projects:   projects,
 		Apps:       apps,
 		Settings:   cfg,
+		Certs:      certificates.NewService(cfg, apps, opts.DataDir),
 		Setup:      setup.NewService(db, users, opts.SetupToken),
 		Registries: registries,
 		DNS:        dnsProviders,
@@ -118,6 +126,12 @@ func New(db *database.DB, docker app.DockerAPI, opts Options) *Server {
 	// a test is not one, and the endpoint refuses rather than pretending.
 	if m, ok := docker.(registry.Maintainer); ok {
 		srv.Registry.SetMaintainer(m)
+	}
+	// Why a certificate is missing is in Traefik's log and nowhere else.
+	// Without an Engine the report is the same minus those quotations,
+	// which is what a test gets.
+	if e, ok := docker.(certificates.Engine); ok {
+		srv.Certs.SetEngine(e)
 	}
 
 	srv.routes()
@@ -174,6 +188,7 @@ func (s *Server) routes() {
 	setup.NewHandler(s.Setup, userHandler.StartSession).Routes(s.router)
 	project.NewHandler(s.Projects).Routes(s.router, auth)
 	settings.NewHandler(s.Settings).Routes(s.router, auth)
+	certificates.NewHandler(s.Certs).Routes(s.router, auth)
 	extregistry.NewHandler(s.Registries).Routes(s.router, auth)
 	dns.NewHandler(s.DNS).Routes(s.router, auth)
 	s.githubHandler = github.NewHandler(s.GitHub, s.Apps)

--- a/internal/server/servertest/servertest.go
+++ b/internal/server/servertest/servertest.go
@@ -61,6 +61,11 @@ type Fixture struct {
 	Server *server.Server
 	DB     *database.DB
 
+	// DataDir is the instance's state directory, a temporary one per
+	// fixture. Traefik's certificate store lives under it, so a test
+	// about certificates writes one there.
+	DataDir string
+
 	// Admin holds the admin role, and AdminKey is their API key. Use it
 	// to set up whatever a test needs; use AddMember to test
 	// authorization.
@@ -110,9 +115,13 @@ func (noDocker) Logs(context.Context, string, string) (io.ReadCloser, error) {
 func NewEmpty(t testing.TB) *Fixture {
 	t.Helper()
 	db := dbtest.New(t)
+	dataDir := t.TempDir()
 	return &Fixture{
-		Server: server.New(db, noDocker{}, server.Options{WebhookToken: WebhookToken, LocalRegistry: LocalRegistry}),
-		DB:     db,
+		Server: server.New(db, noDocker{}, server.Options{
+			WebhookToken: WebhookToken, LocalRegistry: LocalRegistry, DataDir: dataDir,
+		}),
+		DB:      db,
+		DataDir: dataDir,
 	}
 }
 
@@ -122,11 +131,14 @@ func NewEmpty(t testing.TB) *Fixture {
 func NewUnclaimed(t testing.TB, token setup.Token) *Fixture {
 	t.Helper()
 	db := dbtest.New(t)
+	dataDir := t.TempDir()
 	return &Fixture{
 		Server: server.New(db, noDocker{}, server.Options{
-			WebhookToken: WebhookToken, LocalRegistry: LocalRegistry, SetupToken: token,
+			WebhookToken: WebhookToken, LocalRegistry: LocalRegistry,
+			SetupToken: token, DataDir: dataDir,
 		}),
-		DB: db,
+		DB:      db,
+		DataDir: dataDir,
 	}
 }
 
@@ -149,7 +161,10 @@ func newFixture(t testing.TB, docker app.DockerAPI, domain string) *Fixture {
 	ctx := context.Background()
 	db := dbtest.New(t)
 
-	srv := server.New(db, docker, server.Options{WebhookToken: WebhookToken, LocalRegistry: LocalRegistry})
+	dataDir := t.TempDir()
+	srv := server.New(db, docker, server.Options{
+		WebhookToken: WebhookToken, LocalRegistry: LocalRegistry, DataDir: dataDir,
+	})
 	if domain != "" {
 		if err := srv.Settings.SeedFromEnv(ctx, map[string]string{settings.Domain: domain}); err != nil {
 			t.Fatalf("configure the fixture's domain: %v", err)
@@ -163,7 +178,7 @@ func newFixture(t testing.TB, docker app.DockerAPI, domain string) *Fixture {
 	}
 
 	return &Fixture{
-		Server: srv, DB: db,
+		Server: srv, DB: db, DataDir: dataDir,
 		Admin: admin, AdminKey: adminKey,
 		Project: p, Environment: env,
 	}

--- a/web/src/app/(dashboard)/certificates/page.tsx
+++ b/web/src/app/(dashboard)/certificates/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { ErrorAlert } from "@/components/error-alert";
+import { LoadingRows } from "@/components/loading";
+import { Notice } from "@/components/notice";
+import { PageHeader, SectionHeader } from "@/components/page-header";
+import { StatusBadge } from "@/components/status-badge";
+import { Card } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { api, type Certificate, type CertificateReport, type MissingReason } from "@/lib/api";
+import { message } from "@/lib/errors";
+
+// What this instance holds, and what it is missing.
+//
+// Nothing on this page issues, renews or deletes anything: Traefik does
+// all of it, thirty days before expiry, and the only store is its own
+// file. So the page answers the two questions that store cannot — which
+// certificate belongs to which app, and why a name that should have one
+// does not.
+export default function Certificates() {
+  const report = useQuery({
+    queryKey: ["certificates"],
+    queryFn: () => api.get<CertificateReport>("/certificates"),
+  });
+
+  const data = report.data;
+
+  return (
+    <>
+      <PageHeader
+        title="Certificates"
+        sub="Every certificate this instance holds, and every name it serves that has none."
+      />
+
+      {report.error && <ErrorAlert error={message(report.error)} />}
+
+      {data && !data.tls_enabled && (
+        <Notice tone="warning">
+          This instance has no domain, so Traefik runs with no certificate resolver and asks for
+          nothing. Apps are served over plain HTTP until one is set under{" "}
+          <Link href="/settings" className="underline underline-offset-4">
+            Instance
+          </Link>
+          .
+        </Notice>
+      )}
+
+      {data && data.missing.length > 0 && (
+        <>
+          <SectionHeader
+            title="Waiting"
+            sub="Names this instance routes with no certificate behind them."
+          />
+          <Card className="mb-8 py-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Serves</TableHead>
+                  <TableHead>Why</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.missing.map((m) => (
+                  <TableRow key={m.host}>
+                    <TableCell className="font-mono text-xs">
+                      <div className="max-w-[20rem] whitespace-normal break-all">{m.host}</div>
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      <div className="max-w-[14rem] whitespace-normal break-all">
+                        <Serves app={m.app} instance={m.instance} />
+                      </div>
+                    </TableCell>
+                    {/* Bounded so the sentence wraps rather than pushing the
+                        table sideways, and the quotation scrolls inside
+                        itself — a log line is one long line by nature. */}
+                    <TableCell className="text-xs text-muted-foreground">
+                      <div className="max-w-[26rem] whitespace-normal">
+                        {WHY[m.reason]}
+                        {m.detail && (
+                          <p className="mt-1 overflow-x-auto whitespace-nowrap font-mono text-[11px] text-warning">
+                            {m.detail}
+                          </p>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+        </>
+      )}
+
+      <SectionHeader
+        title="Issued"
+        sub={
+          data?.acme_email
+            ? `Let's Encrypt has ${data.acme_email} as the contact for this instance.`
+            : "Renewal is automatic, thirty days before expiry."
+        }
+      />
+      <Card className="py-0">
+        {report.isLoading ? (
+          <LoadingRows />
+        ) : data && data.certificates.length > 0 ? (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Serves</TableHead>
+                <TableHead>Issuer</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead>State</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.certificates.map((c) => (
+                <TableRow key={c.host}>
+                  <TableCell className="font-mono text-xs">
+                    <div className="max-w-[22rem] whitespace-normal break-all">
+                      {c.host}
+                      {c.sans && c.sans.length > 0 && (
+                        <span className="ml-2 text-muted-foreground">+ {c.sans.join(", ")}</span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    <div className="max-w-[16rem] whitespace-normal break-all">
+                      <Serves app={c.app} instance={c.instance} orphan={c.orphan} />
+                    </div>
+                  </TableCell>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {c.issuer || "—"}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                    <span className="font-mono">{day(c.not_after)}</span>{" "}
+                    <span>{remaining(c.not_after)}</span>
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge value={state(c)} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <p className="p-6 text-sm text-muted-foreground">
+            Nothing issued yet. A certificate is asked for the first time somebody reaches an app at
+            a name this instance serves.
+          </p>
+        )}
+      </Card>
+
+      <p className="mt-4 text-xs leading-relaxed text-muted-foreground">
+        Traefik issues and renews these on its own, thirty days before expiry, and keeps them in its
+        own store — there is nothing to press here. A name stuck waiting is usually one that does
+        not resolve to this host, or an app that has not been deployed since the name was added.
+      </p>
+    </>
+  );
+}
+
+// Why each missing name is missing, in the words the reason is worth
+// reading in: what to do about it.
+const WHY: Record<MissingReason, string> = {
+  tls_not_configured: "This instance has no domain, so no certificate is asked for at all.",
+  not_deployed:
+    "Added after the app's last deploy. A container keeps the routing it was created with — redeploy and Traefik is told about it.",
+  pending:
+    "Traefik knows the name and has not got a certificate for it. Normal for a minute after a deploy; after that, check the name resolves to this host.",
+};
+
+// Who a name belongs to. An app is a link, because the next thing
+// somebody does about it is open the app.
+function Serves({ app, instance, orphan }: { app?: string; instance?: boolean; orphan?: boolean }) {
+  if (orphan) {
+    return <span className="text-muted-foreground">nothing — unused</span>;
+  }
+  if (instance) {
+    return <span className="text-muted-foreground">this instance</span>;
+  }
+  if (!app) return <span className="text-muted-foreground">—</span>;
+  return (
+    <Link href={`/projects/${app}`} className="font-mono underline underline-offset-4">
+      {app}
+    </Link>
+  );
+}
+
+// Traefik renews thirty days out, so a certificate still inside two
+// weeks is one whose renewal is not working.
+function state(c: Certificate): string {
+  const days = daysLeft(c.not_after);
+  if (days < 0) return "expired";
+  if (days < 14) return "expiring";
+  return "valid";
+}
+
+function daysLeft(notAfter: string): number {
+  return Math.floor((new Date(notAfter).getTime() - Date.now()) / 86_400_000);
+}
+
+function day(value: string): string {
+  return new Date(value).toISOString().slice(0, 10);
+}
+
+function remaining(notAfter: string): string {
+  const days = daysLeft(notAfter);
+  if (days < 0) return `${-days}d ago`;
+  if (days === 0) return "today";
+  return `in ${days}d`;
+}

--- a/web/src/components/shell.tsx
+++ b/web/src/components/shell.tsx
@@ -8,6 +8,7 @@ import {
   GlobeIcon,
   LogOutIcon,
   ServerCogIcon,
+  ShieldCheckIcon,
   UserRoundIcon,
 } from "lucide-react";
 import Link from "next/link";
@@ -65,6 +66,7 @@ const sections: { label?: string; items: NavItem[] }[] = [
       { href: "/registries", label: "Registries", icon: ContainerIcon, owns: ["/registries"] },
       { href: "/git", label: "Git Providers", icon: GitBranchIcon, owns: ["/git"] },
       { href: "/dns", label: "DNS Providers", icon: GlobeIcon, owns: ["/dns"] },
+      { href: "/certificates", label: "Certificates", icon: ShieldCheckIcon },
       { href: "/settings", label: "Instance", icon: ServerCogIcon },
     ],
   },

--- a/web/src/components/status-badge.tsx
+++ b/web/src/components/status-badge.tsx
@@ -29,6 +29,13 @@ const tones: Record<string, Tone> = {
     edge: "border-border-strong",
     pulse: true,
   },
+  // A certificate's three. Traefik renews thirty days before expiry, so
+  // a certificate still inside two weeks is one whose renewal is not
+  // working — amber, not green — and an expired one is already failing
+  // handshakes.
+  valid: { dot: "bg-success", text: "text-success", edge: "border-success/40" },
+  expiring: { dot: "bg-warning", text: "text-warning", edge: "border-warning/40" },
+  expired: { dot: "bg-destructive", text: "text-destructive", edge: "border-destructive/40" },
   stopped: {
     dot: "bg-subtle-foreground",
     text: "text-muted-foreground",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -264,3 +264,43 @@ export type ApiKey = {
 
 export type ResolvedVar = { key: string; value: string; source: string };
 export type EnvView = { vars: Record<string, string>; effective?: ResolvedVar[] };
+
+// One TLS certificate this instance holds. Traefik issues and renews
+// them; this is what it has, read out of its own store.
+export type Certificate = {
+  host: string;
+  sans?: string[];
+  issuer: string;
+  not_before: string;
+  not_after: string;
+  serial: string;
+  // The app served at that name, as its reference. Absent for the
+  // instance's own names and for one nothing serves any more.
+  app?: string;
+  instance?: boolean;
+  // Nothing on this instance answers there now. Still valid, just
+  // unused.
+  orphan?: boolean;
+};
+
+// Why a name this instance routes has no certificate. The three are
+// three different jobs: configure the instance, redeploy the app, or
+// look at what Traefik said.
+export type MissingReason = "tls_not_configured" | "not_deployed" | "pending";
+
+export type MissingCertificate = {
+  host: string;
+  app?: string;
+  instance?: boolean;
+  reason: MissingReason;
+  // The last thing Traefik's log said about that name, when it said
+  // anything. A quotation, not a contract.
+  detail?: string;
+};
+
+export type CertificateReport = {
+  tls_enabled: boolean;
+  acme_email?: string;
+  certificates: Certificate[];
+  missing: MissingCertificate[];
+};


### PR DESCRIPTION
A new module and a page under **Platform → Certificates**.

## Where the data comes from

Traefik issues the certificates, through the ACME resolver it is started with, and keeps them in `<data dir>/letsencrypt/acme.json` — the whole store, with no API in front of it and no row about it anywhere in Cubeship. The daemon can read that file because the data directory is mounted at the same path inside and out, which is the same reason everything else about that directory works.

`internal/certificates` decodes each entry's PEM and takes the leaf's own facts: names, issuer, validity, serial. The private key sits beside it in the file and is never read — nothing above this could do anything with it that is not a leak.

## What the store cannot answer

The comparison is the point. Every certificate is lined up against every name this instance routes — an app's domains, plus the instance's own two — so the report can say:

- **which app** each certificate serves, and which one serves nothing any more (still valid, just paid for);
- **which names have none, and why**: `tls_not_configured` (no domain, so Traefik was started with no resolver at all), `not_deployed` (the name was added after the app's last deploy, and a container keeps the labels it was created with), or `pending` (Traefik knows the name and has not got one — normal for a minute after a deploy, and after that a name that does not resolve here).

For a pending name the report quotes the ACME error out of `docker logs cubeship-traefik`, because it appears nowhere else. That is a quotation, not a contract: a log line that stops matching leaves the field empty and the report is still the report. Without a Docker client that can inspect containers — a test, say — the whole step is skipped.

## Read-only on purpose

Renewing or deleting means editing a file Traefik owns while it runs, which is only safe with the container stopped — a few seconds of downtime for every app — and every re-issue spends one of Let's Encrypt's 50 certificates per registered domain per week, which for an sslip.io instance is shared with everyone else using sslip.io. That is a decision to make deliberately, not a button beside a table. The page says so.

## Surface

- `GET /certificates`, admin only, documented in the OpenAPI (this is how the instance is wired, not an app's own configuration).
- `web/src/app/(dashboard)/certificates` — a "Waiting" table with the reason and the quotation, and an "Issued" table with what each certificate serves, its issuer, when it expires and a state badge (`valid` / `expiring` under 14 days, since Traefik renews at 30 / `expired`). Those three tones are added to `status-badge`, which is the one place a state's colour is decided.
- `server.Options` gains `DataDir`; the fixture gets one per test so a test can write a store.

## Verified

- Go suite green. New tests cover: parsing a real store (certificates generated in the test and signed by a CA, so the issuer is a CA's name), ordering by expiry, the SAN list, a missing and an empty store both being a state rather than an error, one unreadable entry not hiding the rest, the whole reconcile matrix (served/orphan/pending/not-deployed/no-TLS/SAN-covered), admin-only access, and the full path from the file on disk to the attributed report over HTTP.
- The page rendered in Chromium against a stand-in daemon, with long sslip.io names and a real Traefik error line, to check the tables fit rather than scrolling out of the card.
- `gofmt`, `go vet` (including the integration build tag), shell syntax, `biome`, `pnpm typecheck`, `pnpm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf9kXYsFS5voL84pLFTYiJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf9kXYsFS5voL84pLFTYiJ)_