### PR TITLE
Check the registry's name is really routed, and carry what Traefik says

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -754,7 +754,20 @@ after the app's last deploy — a container keeps the labels it was
 created with — or Traefik knowing the name and not having got one yet.
 That last case quotes the ACME error from `docker logs
 cubeship-traefik`, because it appears nowhere else; a log line that stops
-matching leaves the field empty and the report is still the report.
+matching leaves the field empty and the report is still the report. The
+complaints that name no host are carried too, in `traefik_says`: the
+commonest failure on a default install is a rate limit, and Let's
+Encrypt counts every name under `sslip.io` against one weekly allowance
+shared with everyone else using it, because `sslip.io` is not on the
+Public Suffix List.
+
+**"Routed" is checked, not assumed.** The daemon's own name comes from
+the dynamic file the daemon writes, so it is there whenever there is a
+domain; the registry's comes from its container's labels, and a
+container keeps the labels it was created with. One made before the
+domain existed carries no router at all, so Traefik has never heard of
+the name and `pending` would be a lie — the report inspects the
+container and says `not_deployed` instead.
 
 **It is read-only on purpose.** Renewing or deleting means editing a file
 Traefik owns while it runs, which is only safe with the container

--- a/internal/certificates/certificates.go
+++ b/internal/certificates/certificates.go
@@ -116,6 +116,12 @@ type Report struct {
 	ACMEEmail    string        `json:"acme_email,omitempty"`
 	Certificates []Certificate `json:"certificates"`
 	Missing      []Missing     `json:"missing"`
+	// TraefikSays is what Traefik has lately complained about while
+	// trying to get certificates, whether or not the complaint names a
+	// host this instance knows. Read out of the container's log, so it
+	// is a quotation and not a contract — and often the only place the
+	// real reason appears, a rate limit especially.
+	TraefikSays []string `json:"traefik_says,omitempty"`
 }
 
 // ServedHost is a name this instance routes and what answers there. It

--- a/internal/certificates/engine_test.go
+++ b/internal/certificates/engine_test.go
@@ -1,0 +1,71 @@
+package certificates
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"cubeship/internal/platform/bootstrap"
+	"cubeship/internal/platform/dockerx"
+)
+
+// fakeEngine stands in for Docker: the two things this module asks it.
+type fakeEngine struct {
+	containers map[string]dockerx.ContainerInfo
+	log        string
+}
+
+func (f fakeEngine) InspectContainerByName(_ context.Context, name string) (dockerx.ContainerInfo, error) {
+	info, ok := f.containers[name]
+	if !ok {
+		return dockerx.ContainerInfo{}, io.EOF
+	}
+	return info, nil
+}
+
+func (f fakeEngine) Logs(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(f.log)), nil
+}
+
+// Three states the registry can be in, and only one of them means the
+// name is really routed.
+func TestWhenTheRegistrysNameCountsAsRouted(t *testing.T) {
+	const host = "registry.example.com"
+	routed := map[string]string{
+		"traefik.enable": "true",
+		"traefik.http.routers.cubeship-registry.rule": "Host(`registry.example.com`)",
+	}
+
+	for name, tc := range map[string]struct {
+		engine Engine
+		want   bool
+	}{
+		"running with a router for it": {
+			fakeEngine{containers: map[string]dockerx.ContainerInfo{
+				bootstrap.RegistryContainerName: {ID: "r", Running: true, Labels: routed},
+			}}, true,
+		},
+		"running with labels from before the domain": {
+			fakeEngine{containers: map[string]dockerx.ContainerInfo{
+				bootstrap.RegistryContainerName: {ID: "r", Running: true, Labels: map[string]string{}},
+			}}, false,
+		},
+		"not running": {
+			fakeEngine{containers: map[string]dockerx.ContainerInfo{
+				bootstrap.RegistryContainerName: {ID: "r", Running: false, Labels: routed},
+			}}, false,
+		},
+		"no container at all": {fakeEngine{}, false},
+		// A report that cannot look must not accuse.
+		"no engine to ask": {nil, true},
+	} {
+		s := &Service{}
+		if tc.engine != nil {
+			s.SetEngine(tc.engine)
+		}
+		if got := s.registryRouted(context.Background(), host); got != tc.want {
+			t.Errorf("%s: routed = %v, want %v", name, got, tc.want)
+		}
+	}
+}

--- a/internal/certificates/explain_test.go
+++ b/internal/certificates/explain_test.go
@@ -1,0 +1,60 @@
+package certificates
+
+import (
+	"strings"
+	"testing"
+)
+
+// Traefik's log is the only place an ACME failure is written down, so
+// what this pulls out of it is the difference between "pending" and
+// knowing why.
+func TestWhatIsTakenOutOfTraefiksLog(t *testing.T) {
+	// A frame header's control bytes in front of a line, the way Docker
+	// hands them over, and the same refusal repeated the way a retry
+	// loop produces it.
+	log := strings.Join([]string{
+		"\x01\x00\x00\x00\x00\x00\x00\x4dtime=\"2026-09-06T11:00:00Z\" level=info msg=\"Configuration loaded\"",
+		"time=\"2026-09-06T12:00:00Z\" level=error msg=\"Unable to obtain ACME certificate for domains \\\"registry.75-119-141-235.sslip.io\\\": error: one or more domains had a problem: acme: error: 429 :: too many certificates already issued for sslip.io\"",
+		"time=\"2026-09-06T12:30:00Z\" level=error msg=\"Unable to obtain ACME certificate for domains \\\"registry.75-119-141-235.sslip.io\\\": error: one or more domains had a problem: acme: error: 429 :: too many certificates already issued for sslip.io\"",
+		"time=\"2026-09-06T13:00:00Z\" level=error msg=\"Unable to obtain ACME certificate for domains \\\"api.example.com\\\": timeout\"",
+		"time=\"2026-09-06T13:05:00Z\" level=debug msg=\"Serving default certificate\"",
+	}, "\n")
+
+	lines := complaints(strings.NewReader(log))
+	if len(lines) != 2 {
+		t.Fatalf("kept %d lines, want the two distinct failures: %v", len(lines), lines)
+	}
+	for _, line := range lines {
+		if strings.ContainsAny(line, "\x00\x01") {
+			t.Errorf("a frame header's bytes came through: %q", line)
+		}
+	}
+
+	// Each name gets the last thing said about it, and a name nothing
+	// was said about gets nothing.
+	if got := about(lines, "registry.75-119-141-235.sslip.io"); !strings.Contains(got, "too many certificates") {
+		t.Errorf("the registry's line is %q", got)
+	}
+	if got := about(lines, "api.example.com"); !strings.Contains(got, "timeout") {
+		t.Errorf("the api's line is %q", got)
+	}
+	if got := about(lines, "quiet.example.com"); got != "" {
+		t.Errorf("a name nothing was said about got %q", got)
+	}
+}
+
+// The lines that name no host are the ones worth keeping too: on a
+// default install the commonest failure is a rate limit against the
+// whole of sslip.io, and that refusal is about the service rather than
+// about any one name.
+func TestAComplaintThatNamesNoHostIsStillKept(t *testing.T) {
+	log := `time="2026-09-06T12:00:00Z" level=error msg="Unable to obtain ACME certificate: acme: error: 429 :: too many certificates already issued"`
+
+	lines := complaints(strings.NewReader(log))
+	if len(lines) != 1 {
+		t.Fatalf("kept %v", lines)
+	}
+	if about(lines, "registry.example.com") != "" {
+		t.Error("a line naming no host was attributed to one")
+	}
+}

--- a/internal/certificates/openapi.go
+++ b/internal/certificates/openapi.go
@@ -26,8 +26,8 @@ func (h *Handler) OpenAPI() openapi.Spec {
 				"host":     openapi.String("A name this instance routes with no certificate behind it."),
 				"app":      openapi.String("The app served there, as its reference. Absent for the instance's own names."),
 				"instance": openapi.Bool("The name is the dashboard's or the registry's."),
-				"reason": openapi.String("`tls_not_configured` — the instance has no domain or no contact address, so Traefik asks for nothing. " +
-					"`not_deployed` — the name was added after the app's last deploy, and a container keeps the labels it was created with, so Traefik has never been told about it. " +
+				"reason": openapi.String("`tls_not_configured` — the instance has no domain, so Traefik asks for nothing. " +
+					"`not_deployed` — nothing is running with that name in its labels: an app not deployed since the name was added, or the registry's container made before the instance had a domain. A container keeps the labels it was created with, so Traefik has never been told about it. " +
 					"`pending` — Traefik knows the name and has not produced a certificate: normal for a minute after a deploy, and after that a name that does not resolve here or a challenge that failed."),
 				"detail": openapi.String("The last thing Traefik's log said about that name, when it said anything. A quotation, not a contract."),
 			}, "host", "reason"),
@@ -36,6 +36,7 @@ func (h *Handler) OpenAPI() openapi.Spec {
 				"acme_email":   openapi.String("The contact Let's Encrypt has, as the store recorded it — which is the one that counts if the setting was changed after registering."),
 				"certificates": openapi.Array(openapi.Ref("Certificate")),
 				"missing":      openapi.Array(openapi.Ref("MissingCertificate")),
+				"traefik_says": openapi.Array(openapi.String("A line Traefik logged while failing to get a certificate, whether or not it names a host. Often the only place the real reason appears — a rate limit especially, which on a default install is shared with everyone else using the same wildcard DNS service.")),
 			}, "tls_enabled", "certificates", "missing"),
 		},
 		Paths: map[string]openapi.PathItem{

--- a/internal/certificates/reconcile_test.go
+++ b/internal/certificates/reconcile_test.go
@@ -89,3 +89,28 @@ func TestANameOnASANIsNotMissing(t *testing.T) {
 		t.Errorf("missing is %+v, want none", missing)
 	}
 }
+
+// The registry is routed by its container's labels, and a container
+// keeps the labels it was created with — one made before the instance
+// had a domain carries no router at all. Traefik has then never heard of
+// the name, and "pending" would be a lie: nothing is coming.
+func TestTheRegistrysNameIsOnlyServedIfItsContainerSaysSo(t *testing.T) {
+	served := []ServedHost{
+		{Host: "cubeship.example.com", Instance: true, Deployed: true},
+		{Host: "registry.cubeship.example.com", Instance: true, Deployed: false},
+	}
+
+	_, missing := reconcile(nil, served, true)
+
+	reasons := map[string]Reason{}
+	for _, m := range missing {
+		reasons[m.Host] = m.Reason
+	}
+	if reasons["cubeship.example.com"] != ReasonPending {
+		t.Errorf("the daemon's own name is %q", reasons["cubeship.example.com"])
+	}
+	if reasons["registry.cubeship.example.com"] != ReasonNotDeployed {
+		t.Errorf("the registry's name is %q, want %q",
+			reasons["registry.cubeship.example.com"], ReasonNotDeployed)
+	}
+}

--- a/internal/certificates/service.go
+++ b/internal/certificates/service.go
@@ -5,23 +5,27 @@ import (
 	"context"
 	"errors"
 	"io"
+	"regexp"
 	"sort"
 	"strings"
 
 	"cubeship/internal/app"
+	"cubeship/internal/platform/bootstrap"
 	"cubeship/internal/platform/dockerx"
 	"cubeship/internal/settings"
 	"cubeship/internal/user"
 )
 
-// TraefikContainer is the container whose log says why a certificate was
-// not issued. It must match bootstrap.TraefikContainerOpts.
-const TraefikContainer = "cubeship-traefik"
+// logTail is how much of Traefik's log is read looking for a reason.
+//
+// Far enough back to cover a certificate that failed hours ago — ACME
+// retries are quiet and the failure that matters is often the first one
+// — and short enough that reading it is not a job.
+const logTail = "5000"
 
-// logTail is how much of Traefik's log is read looking for a reason. Far
-// enough back to cover the last few deploys, short enough that reading
-// it is not a job.
-const logTail = "2000"
+// maxComplaints bounds what a report carries out of the log. Enough to
+// see a pattern, not so much that the page becomes the log.
+const maxComplaints = 5
 
 // Engine is the little of Docker this module needs: the ACME failures
 // are in Traefik's log and nowhere else.
@@ -88,7 +92,7 @@ func (s *Service) Report(ctx context.Context, caller *user.User) (Report, error)
 	report.ACMEEmail = email
 
 	report.Certificates, report.Missing = reconcile(certs, served, report.TLSEnabled)
-	s.explain(ctx, report.Missing)
+	report.TraefikSays = s.explain(ctx, report.Missing)
 	return report, nil
 }
 
@@ -158,12 +162,21 @@ func (s *Service) servedHosts(ctx context.Context, values settings.Values) ([]Se
 	var out []ServedHost
 
 	if domain := values.Get(settings.Domain); domain != "" {
-		// Both are routed by Traefik with the same resolver: the
-		// dashboard and API at the domain itself, the registry beside
-		// it. Neither belongs to an app.
+		// Both are routed by Traefik with the same resolver, and neither
+		// belongs to an app — but they are routed by different means.
+		// The daemon's own name comes from the file the daemon writes,
+		// so it is there whenever there is a domain. The registry's
+		// comes from its container's labels, and a container keeps the
+		// labels it was created with: one made before the domain existed
+		// carries no router at all, and Traefik has never heard of the
+		// name.
+		registryHost := settings.RegistryHostFor(domain)
 		out = append(out,
 			ServedHost{Host: settings.APIHostFor(domain), Instance: true, Deployed: true},
-			ServedHost{Host: settings.RegistryHostFor(domain), Instance: true, Deployed: true})
+			ServedHost{
+				Host: registryHost, Instance: true,
+				Deployed: s.registryRouted(ctx, registryHost),
+			})
 	}
 
 	apps, err := s.apps.Repo().ListScoped(ctx)
@@ -193,16 +206,45 @@ func (s *Service) servedHosts(ctx context.Context, values settings.Values) ([]Se
 	return out, nil
 }
 
-// explain fills in what Traefik said about each name it could not get a
-// certificate for.
+// registryRouted reports whether the registry's container is running
+// with a Traefik router for this name.
+//
+// Without an Engine there is no way to tell, and the answer is yes: a
+// report that cannot look must not accuse.
+func (s *Service) registryRouted(ctx context.Context, host string) bool {
+	if s.engine == nil {
+		return true
+	}
+	info, err := s.engine.InspectContainerByName(ctx, bootstrap.RegistryContainerName)
+	if err != nil || !info.Running {
+		return false
+	}
+	for key, value := range info.Labels {
+		if strings.HasPrefix(key, "traefik.http.routers.") && strings.HasSuffix(key, ".rule") &&
+			strings.Contains(strings.ToLower(value), app.NormalizeHost(host)) {
+			return true
+		}
+	}
+	return false
+}
+
+// explain fills in what Traefik said about the names that have no
+// certificate, and returns what it has been complaining about lately.
 //
 // It reads the container's log, because Traefik has no API for this and
 // the ACME error appears nowhere else. That makes it a quotation rather
 // than a contract: a log line that stops matching leaves the field
 // empty, and the report is still the report.
-func (s *Service) explain(ctx context.Context, missing []Missing) {
+//
+// The unattributed lines matter as much as the attributed ones. The
+// commonest failure on a default install is a rate limit — sslip.io is
+// not on the Public Suffix List, so Let's Encrypt counts every name
+// under it against one weekly allowance shared with everybody else
+// using the service — and that refusal does not always name the host it
+// was asked for.
+func (s *Service) explain(ctx context.Context, missing []Missing) []string {
 	if s.engine == nil || len(missing) == 0 {
-		return
+		return nil
 	}
 	pending := false
 	for _, m := range missing {
@@ -212,60 +254,81 @@ func (s *Service) explain(ctx context.Context, missing []Missing) {
 		}
 	}
 	if !pending {
-		return
+		return nil
 	}
 
-	info, err := s.engine.InspectContainerByName(ctx, TraefikContainer)
+	info, err := s.engine.InspectContainerByName(ctx, bootstrap.TraefikContainerName)
 	if err != nil || info.ID == "" {
-		return
+		return nil
 	}
 	logs, err := s.engine.Logs(ctx, info.ID, logTail)
 	if err != nil {
-		return
+		return nil
 	}
 	defer logs.Close()
 
-	lines := errorLines(logs)
+	lines := complaints(logs)
 	for i := range missing {
 		if missing[i].Reason != ReasonPending {
 			continue
 		}
-		if line, ok := lines[app.NormalizeHost(missing[i].Host)]; ok {
-			missing[i].Detail = line
-		}
+		missing[i].Detail = about(lines, missing[i].Host)
 	}
+	if len(lines) > maxComplaints {
+		lines = lines[len(lines)-maxComplaints:]
+	}
+	return lines
 }
 
-// errorLines keeps the last thing Traefik complained about, per host.
+// complaints keeps the lines where Traefik said something went wrong
+// with a certificate, oldest first.
 //
 // Docker frames the log, and a frame header is a few bytes of binary in
 // front of each line. Nothing here needs to be exact about it: the
 // scanner reads lines, the header lands at the start of one, and the
-// host is looked for anywhere in it.
-func errorLines(r io.Reader) map[string]string {
-	out := map[string]string{}
+// unprintable bytes are dropped rather than parsed.
+func complaints(r io.Reader) []string {
+	var out []string
+	seen := map[string]bool{}
+
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
 	for scanner.Scan() {
 		line := strings.TrimSpace(strings.Map(printable, scanner.Text()))
 		lower := strings.ToLower(line)
-		if !strings.Contains(lower, "error") && !strings.Contains(lower, "unable") {
-			continue
-		}
 		if !strings.Contains(lower, "acme") && !strings.Contains(lower, "certificate") {
 			continue
 		}
-		// The host appears in the message; which one it is decides
-		// whose line this is.
-		for _, field := range strings.FieldsFunc(lower, func(r rune) bool {
-			return r == '"' || r == ' ' || r == '\'' || r == ',' || r == ':'
-		}) {
-			if strings.Contains(field, ".") {
-				out[app.NormalizeHost(field)] = line
-			}
+		if !strings.Contains(lower, "error") && !strings.Contains(lower, "unable") &&
+			!strings.Contains(lower, "too many") && !strings.Contains(lower, "fail") {
+			continue
 		}
+		// Traefik retries, so the same refusal appears over and over
+		// with a new timestamp each time. The page wants the distinct
+		// things that are wrong, not how often it tried.
+		key := timestamps.ReplaceAllString(lower, "")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, line)
 	}
 	return out
+}
+
+// timestamps is what makes one retry look like another: the same
+// refusal, logged again a minute later.
+var timestamps = regexp.MustCompile(`(?i)"?time"?[=:]\s*"?[^"\s]+"?`)
+
+// about is the last distinct thing said about one name.
+func about(lines []string, host string) string {
+	host = app.NormalizeHost(host)
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.Contains(strings.ToLower(lines[i]), host) {
+			return lines[i]
+		}
+	}
+	return ""
 }
 
 // printable drops the frame header's control bytes, which would

--- a/internal/platform/bootstrap/bootstrap.go
+++ b/internal/platform/bootstrap/bootstrap.go
@@ -23,6 +23,11 @@ import (
 
 const registryPort = 5000
 
+// TraefikContainerName is the reverse proxy. It is exported because it
+// is also the only place an ACME failure is recorded: certificates reads
+// its log to say why a name has no certificate.
+const TraefikContainerName = "cubeship-traefik"
+
 // RegistryContainerName is the embedded registry, and the name the
 // daemon pulls from when both are containers.
 const RegistryContainerName = "cubeship-registry"
@@ -470,7 +475,7 @@ func TraefikContainerOpts(cfg *config.Config, tls bool, acmeEmail string) docker
 		}
 	}
 	return dockerx.ContainerOpts{
-		Name:  "cubeship-traefik",
+		Name:  TraefikContainerName,
 		Image: "traefik:v3.1",
 		Cmd:   cmd,
 		Binds: []string{

--- a/web/src/app/(dashboard)/certificates/page.tsx
+++ b/web/src/app/(dashboard)/certificates/page.tsx
@@ -85,7 +85,9 @@ export default function Certificates() {
                         itself — a log line is one long line by nature. */}
                     <TableCell className="text-xs text-muted-foreground">
                       <div className="max-w-[26rem] whitespace-normal">
-                        {WHY[m.reason]}
+                        {m.instance && m.reason === "not_deployed"
+                          ? WHY_REGISTRY_NOT_DEPLOYED
+                          : WHY[m.reason]}
                         {m.detail && (
                           <p className="mt-1 overflow-x-auto whitespace-nowrap font-mono text-[11px] text-warning">
                             {m.detail}
@@ -97,6 +99,27 @@ export default function Certificates() {
                 ))}
               </TableBody>
             </Table>
+          </Card>
+        </>
+      )}
+
+      {data?.traefik_says && data.traefik_says.length > 0 && (
+        <>
+          <SectionHeader
+            title="What Traefik says"
+            sub="The last distinct things it logged while trying to get certificates. This is the only place an ACME refusal is written down."
+          />
+          <Card className="mb-8">
+            <div className="space-y-2 p-4">
+              {data.traefik_says.map((line) => (
+                <p
+                  key={line}
+                  className="overflow-x-auto whitespace-nowrap font-mono text-[11px] text-warning"
+                >
+                  {line}
+                </p>
+              ))}
+            </div>
           </Card>
         </>
       )}
@@ -175,10 +198,16 @@ export default function Certificates() {
 const WHY: Record<MissingReason, string> = {
   tls_not_configured: "This instance has no domain, so no certificate is asked for at all.",
   not_deployed:
-    "Added after the app's last deploy. A container keeps the routing it was created with — redeploy and Traefik is told about it.",
+    "Nothing is running with this name in its labels. A container keeps the routing it was created with, so Traefik has never been told about it — redeploy the app and it will be.",
   pending:
     "Traefik knows the name and has not got a certificate for it. Normal for a minute after a deploy; after that, check the name resolves to this host.",
 };
+
+// The registry is not an app, so "redeploy it" is not the answer: its
+// container is the instance's own, and the daemon replaces it when the
+// domain changes.
+const WHY_REGISTRY_NOT_DEPLOYED =
+  "The registry's container is not running with this name in its labels — it was made before the instance had a domain, or it is not running at all. Setting the domain again under Instance rebuilds it.";
 
 // Who a name belongs to. An app is a link, because the next thing
 // somebody does about it is open the app.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -303,4 +303,7 @@ export type CertificateReport = {
   acme_email?: string;
   certificates: Certificate[];
   missing: MissingCertificate[];
+  // What Traefik has lately complained about, whether or not the line
+  // names a host. Often the only place the real reason appears.
+  traefik_says?: string[];
 };


### PR DESCRIPTION
Follow-up to #5, from a real instance reporting `registry.<domain>` as **pending** with no detail.

## "Pending" was a promise the report could not make

The instance's own two names were reported as routed without checking. For the daemon's own name that holds — it comes from the dynamic file the daemon writes, so it exists whenever there is a domain. For the registry it does not: that name is routed by its **container's labels**, and a container keeps the labels it was created with. One made before the instance had a domain carries no router at all, so Traefik has never heard of the name and nothing is coming — while the page said "pending", which means "wait".

It now inspects the container. Running, and carrying a router rule for that name, or the reason is `not_deployed`, with wording for the registry rather than the app-shaped "redeploy the app": its container is the instance's own, and setting the domain again rebuilds it.

## The refusal that names no host

The other half is a name Traefik does know that stays without a certificate. The ACME error is only ever in Traefik's log — and it does not always name the host it was asked for. The commonest one on a default install is a rate limit against the whole of `sslip.io`, which Let's Encrypt counts as a single registered domain because `sslip.io` is not on the Public Suffix List: 50 certificates a week, shared with everyone else using the service.

So the report carries the last distinct complaints as `traefik_says`, whether or not they name a known host, and the page shows them under **What Traefik says**. Retries are collapsed by ignoring the timestamp, so the same refusal logged every half hour is one line. The log tail went from 2000 to 5000 lines, because the failure that matters is often the first one and ACME retries are quiet.

## Verified

- New tests: the three states the registry's container can be in (routed / labels from before the domain / not running / no container at all / no engine to ask, which must not accuse); what is taken out of a Traefik log, including Docker's frame-header bytes, retry collapsing, per-host attribution and a complaint that names no host; and the reconcile case where the registry is not routed.
- Existing suite green; `gofmt`, `go vet` (with the integration tag), `biome`, `pnpm typecheck`, `pnpm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf9kXYsFS5voL84pLFTYiJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf9kXYsFS5voL84pLFTYiJ)_