### PR TITLE
Drop the "this app answers at no name" notices

### DIFF
--- a/web/src/app/(dashboard)/projects/[project]/[env]/[app]/page.tsx
+++ b/web/src/app/(dashboard)/projects/[project]/[env]/[app]/page.tsx
@@ -92,18 +92,6 @@ function Detail({ reference }: { reference: string }) {
         }
       />
 
-      {app.domains.length === 0 && (
-        <Notice>
-          This app answers at no name, so only its neighbours on this instance reach it — by
-          container name. That is all a worker needs; anything meant to be visited wants a domain,
-          in{" "}
-          <Link href={`/projects/${reference}/settings`} className="underline underline-offset-4">
-            settings
-          </Link>
-          .
-        </Notice>
-      )}
-
       <Origin app={app} />
 
       <Deployments

--- a/web/src/components/app-network.tsx
+++ b/web/src/components/app-network.tsx
@@ -7,7 +7,6 @@ import { useEffect, useMemo, useState } from "react";
 import { ActionButton } from "@/components/action-button";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { ErrorAlert } from "@/components/error-alert";
-import { Notice } from "@/components/notice";
 import { SectionHeader } from "@/components/page-header";
 import { SearchableSelect } from "@/components/searchable-select";
 import { TextField } from "@/components/text-field";
@@ -68,14 +67,6 @@ export function AppNetwork({ app, onSaved }: { app: App; onSaved: (a: App) => vo
       />
 
       <ErrorAlert error={error} />
-
-      {app.domains.length === 0 && (
-        <Notice>
-          This app answers at no name, so nothing outside this instance reaches it. It still
-          deploys, and other apps here reach it by container name — which is all a worker or a queue
-          consumer needs.
-        </Notice>
-      )}
 
       {app.domains.length > 0 && (
         <Card className="mb-4 py-0">


### PR DESCRIPTION
Two notices, one on the app page and one over its network settings, saying the same thing twice about a state that is not a problem.

The header already reads `no domain` beside the status, which is the whole of what there is to know: an app with none runs, and its neighbours reach it by container name. A notice is for something the reader has to act on — these were an explanation of a deliberate design, printed on every worker forever.

Pure deletion: 21 lines, two files, plus the now-unused `Notice` import in `app-network.tsx`. The other notices on the page stay — "nowhere to push yet" and the one about a Git source not autodeploying are both things to act on.

`biome`, `pnpm typecheck` and `pnpm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf9kXYsFS5voL84pLFTYiJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf9kXYsFS5voL84pLFTYiJ)_